### PR TITLE
[ADD] Github 로그인, 인증기능 추가

### DIFF
--- a/Backend/Passport/github.js
+++ b/Backend/Passport/github.js
@@ -1,0 +1,18 @@
+const passport = require('passport');
+const GithubStrategy = require('passport-github').Strategy;
+
+module.exports = () => {
+  passport.use(
+    new GithubStrategy(
+      {
+        clientID: process.env.GITHUB_ACCESS_ID,
+        clientSecret: process.env.GITHUB_ACCESS_SECRET,
+        callbackURL: 'http://localhost:3000/auth/github/callback',
+      },
+
+      (accessToken, refreshToken, profile, done) => {
+        return done(null, { username: profile.username, imgUrl: profile._json.avatar_url });
+      },
+    ),
+  );
+};

--- a/Backend/Passport/index.js
+++ b/Backend/Passport/index.js
@@ -1,0 +1,5 @@
+const GithubStrategy = require('./github');
+
+module.exports = () => {
+  GithubStrategy();
+};

--- a/Backend/Passport/token.js
+++ b/Backend/Passport/token.js
@@ -1,0 +1,17 @@
+const jwt = require('jsonwebtoken');
+
+exports.tokenCheck = (req, res, next) => {
+  const cookie = req.cookies['jwt'];
+  try {
+    jwt.verify(cookie, 'secretkey');
+    next();
+  } catch (err) {
+    res.status(401).json();
+  }
+};
+
+exports.tokenAllocate = (req, res) => {
+  const encodedToken = jwt.sign(req.user, 'secretkey');
+  res.cookie('jwt', encodedToken);
+  res.redirect('http://localhost:8000/issues');
+};

--- a/Backend/Passport/token.js
+++ b/Backend/Passport/token.js
@@ -1,9 +1,9 @@
 const jwt = require('jsonwebtoken');
 
 exports.tokenCheck = (req, res, next) => {
-  const cookie = req.cookies['jwt'];
   try {
-    jwt.verify(cookie, 'secretkey');
+    const cookie = req.cookies.jwt;
+    jwt.verify(cookie, process.env.TOKEN_SECRET_KEY);
     next();
   } catch (err) {
     res.status(401).json();
@@ -11,7 +11,7 @@ exports.tokenCheck = (req, res, next) => {
 };
 
 exports.tokenAllocate = (req, res) => {
-  const encodedToken = jwt.sign(req.user, 'secretkey');
+  const encodedToken = jwt.sign(req.user, process.env.TOKEN_SECRET_KEY);
   res.cookie('jwt', encodedToken);
   res.redirect('http://localhost:8000/issues');
 };

--- a/Backend/Passport/token.js
+++ b/Backend/Passport/token.js
@@ -6,7 +6,8 @@ exports.tokenCheck = (req, res, next) => {
     jwt.verify(cookie, process.env.TOKEN_SECRET_KEY);
     next();
   } catch (err) {
-    res.status(401).json();
+    // res.status(401).json();
+    res.redirect('http://localhost:8000');
   }
 };
 

--- a/Backend/app.js
+++ b/Backend/app.js
@@ -1,15 +1,59 @@
 const express = require('express');
 const logger = require('morgan');
+const cookieParser = require('cookie-parser');
+const jwt = require('jsonwebtoken');
+const passport = require('passport');
 const cors = require('cors');
+const GithubStrategy = require('passport-github').Strategy;
 const router = require('./Routes/index');
 
 const app = express();
 app.use(logger('short'));
-
+app.use(cookieParser());
 app.use(express.json());
-app.use(cors());
+app.use(express.urlencoded({ extended: false }));
+app.use(passport.initialize());
+app.use(cors({ origin: true, credentials: true }));
 
-app.use('/api/v1', router);
+const devID = '32f68b56a41a36049266';
+const devSecret = 'de9b7c074adea9772d02a201670eb1648d9d54d1';
+passport.use(
+  new GithubStrategy(
+    {
+      clientID: devID,
+      clientSecret: devSecret,
+      callbackURL: 'http://localhost:3000/auth/github/callback',
+    },
+
+    (accessToken, refreshToken, profile, done) => {
+      return done(null, { username: profile.username, imgUrl: profile._json.avatar_url });
+    },
+  ),
+);
+
+const isLogin = (req, res, next) => {
+  //   console.log(req.session.passport);
+  console.log(req.cookie);
+  console.log(req.headers);
+  //   console.log(req.headers);
+  try {
+    // const decodedToken = jwt.verify()
+  } catch (err) {
+    console.log(err);
+  }
+  next();
+};
+
+app.use('/api/v1', isLogin, router);
+
+app.get('/auth/github', passport.authenticate('github', { session: false }));
+app.get('/auth/github/callback', passport.authenticate('github', { session: false }), (req, res) => {
+  //   console.log(req.user);
+  const encodedToken = jwt.sign(req.user.username, 'secretkey');
+  res.cookie('jwt', encodedToken);
+  res.cookie('profile', req.user.imgUrl);
+  res.redirect('http://localhost:8000/issues');
+});
 
 // app.set('port', 3000);
 app.listen(3000);

--- a/Backend/app.js
+++ b/Backend/app.js
@@ -2,11 +2,12 @@ require('dotenv').config();
 const express = require('express');
 const logger = require('morgan');
 const cookieParser = require('cookie-parser');
-const jwt = require('jsonwebtoken');
 const passport = require('passport');
 const cors = require('cors');
-const GithubStrategy = require('passport-github').Strategy;
+
 const router = require('./Routes/index');
+const passportConfig = require('./Passport');
+const { tokenAllocate, tokenCheck } = require('./Passport/token');
 
 const app = express();
 app.use(logger('short'));
@@ -16,36 +17,10 @@ app.use(express.urlencoded({ extended: false }));
 app.use(passport.initialize());
 app.use(cors({ origin: true, credentials: true }));
 
-passport.use(
-  new GithubStrategy(
-    {
-      clientID: process.env.GITHUB_ACCESS_ID,
-      clientSecret: process.env.GITHUB_ACCESS_SECRET,
-      callbackURL: 'http://localhost:3000/auth/github/callback',
-    },
+passportConfig();
 
-    (accessToken, refreshToken, profile, done) => {
-      return done(null, { username: profile.username, imgUrl: profile._json.avatar_url });
-    },
-  ),
-);
-
-const isLogin = (req, res, next) => {
-  const cookie = req.cookies['jwt'];
-  try {
-    jwt.verify(cookie, 'secretkey');
-    next();
-  } catch (err) {
-    res.status(401).json();
-  }
-};
-
-app.use('/api/v1', isLogin, router);
+app.use('/api/v1', tokenCheck, router);
 app.get('/auth/github', passport.authenticate('github', { session: false }));
-app.get('/auth/github/callback', passport.authenticate('github', { session: false }), (req, res) => {
-  const encodedToken = jwt.sign(req.user, 'secretkey');
-  res.cookie('jwt', encodedToken);
-  res.redirect('http://localhost:8000/issues');
-});
+app.get('/auth/github/callback', passport.authenticate('github', { session: false }), tokenAllocate);
 
 app.listen(3000);

--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -286,6 +286,11 @@
         "concat-map": "0.0.1"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -469,6 +474,15 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
+    "cookie-parser": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
+      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
+      "requires": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6"
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -566,6 +580,14 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -1362,6 +1384,54 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -1399,6 +1469,41 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "long": {
       "version": "4.0.0",

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -12,11 +12,13 @@
   "license": "ISC",
   "dependencies": {
     "aws-sdk": "^2.348.0",
+    "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-session": "^1.17.1",
+    "jsonwebtoken": "^8.5.1",
     "morgan": "^1.10.0",
     "multer": "^1.4.2",
     "mysql2": "^2.2.5",

--- a/Frontend/Views/App.js
+++ b/Frontend/Views/App.js
@@ -3,10 +3,12 @@ import { BrowserRouter as Router, Route } from 'react-router-dom';
 
 import NewIssuePage from './Pages/NewIssuePage';
 import IssueMainPage from './Pages/IssueMainPage';
+import LoginPage from './Pages/LoginPage';
 
 const App = () => {
   return (
     <Router>
+      <Route exact path="/" component={LoginPage} />
       <Route exact path="/issues" component={IssueMainPage} />
       <Route path="/issues/new" component={NewIssuePage} />
     </Router>

--- a/Frontend/Views/Components/NewIssueForm.js
+++ b/Frontend/Views/Components/NewIssueForm.js
@@ -24,14 +24,12 @@ const NewIssueForm = ({ userSelectedData, labelSelectedData, mileSelectedData })
       labels: labelSelectedData.map((elem) => elem.id),
       assignees: userSelectedData.map((elem) => elem.id),
     };
-    await axios
-      .post(ISSUE_URL, postData, { withCredentials: true })
-      .then(() => {
-        window.location.href = 'http://localhost:8000/issues';
-      })
-      .catch(() => {
-        window.location.href = 'http://localhost:8000';
-      });
+    try {
+      await axios.post(ISSUE_URL, postData, { withCredentials: true });
+      window.location.href = 'http://localhost:8000/issues';
+    } catch (err) {
+      window.location.href = 'http://localhost:8000';
+    }
   };
 
   const onSubmitIssue = (e) => {

--- a/Frontend/Views/Components/NewIssueForm.js
+++ b/Frontend/Views/Components/NewIssueForm.js
@@ -14,25 +14,24 @@ const NewIssueForm = ({ userSelectedData, labelSelectedData, mileSelectedData })
     setSubmitDisabled(!(title && comment));
   }, [title, comment]);
 
-  // TODO api 분리
-  const postIssue = async () => {
-    try {
-      return await axios.post('http://localhost:3000/api/v1/issues', {
-        title,
-        comment,
-        userId: 1,
-        milestoneId: mileSelectedData.map((elem) => elem.id)[0],
-        labels: labelSelectedData.map((elem) => elem.id),
-        assignees: userSelectedData.map((elem) => elem.id),
+  const pushIssue = async () => {
+    const ISSUE_URL = 'http://localhost:3000/api/v1/issues';
+    const postData = {
+      title,
+      comment,
+      userId: 1,
+      milestoneId: mileSelectedData.map((elem) => elem.id)[0],
+      labels: labelSelectedData.map((elem) => elem.id),
+      assignees: userSelectedData.map((elem) => elem.id),
+    };
+    await axios
+      .post(ISSUE_URL, postData, { withCredentials: true })
+      .then(() => {
+        window.location.href = 'http://localhost:8000/issues';
+      })
+      .catch(() => {
+        window.location.href = 'http://localhost:8000';
       });
-    } catch (err) {
-      // TODO 에러 처리 부분
-      console.error(err);
-    }
-  };
-
-  const createIssue = async () => {
-    const result = await postIssue();
   };
 
   const onSubmitIssue = (e) => {
@@ -51,7 +50,7 @@ const NewIssueForm = ({ userSelectedData, labelSelectedData, mileSelectedData })
       return;
     }
     e.preventDefault();
-    createIssue();
+    pushIssue();
   };
 
   const onChangeTitle = (e) => {

--- a/Frontend/Views/Components/NewIssueOption.js
+++ b/Frontend/Views/Components/NewIssueOption.js
@@ -19,19 +19,20 @@ const NewIssueOption = ({
     const LABEL_URL = 'http://localhost:3000/api/v1/labels';
     const MILE_URL = 'http://localhost:3000/api/v1/milestones';
 
-    const userProm = axios.get(USER_URL);
-    const labelProm = axios.get(LABEL_URL);
-    const mileProm = axios.get(MILE_URL);
+    const userProm = axios.get(USER_URL, { withCredentials: true });
+    const labelProm = axios.get(LABEL_URL, { withCredentials: true });
+    const mileProm = axios.get(MILE_URL, { withCredentials: true });
 
-    try {
-      const [userResolve, labelResolve, mileResolve] = await Promise.all([userProm, labelProm, mileProm]);
-
-      setUser(userResolve.data);
-      setLabel(labelResolve.data);
-      setMile(mileResolve.data);
-    } catch (err) {
-      console.error(err);
-    }
+    await Promise.all([userProm, labelProm, mileProm])
+      .then((resolve) => {
+        const [userResolve, labelResolve, mileResolve] = resolve;
+        setUser(userResolve.data);
+        setLabel(labelResolve.data);
+        setMile(mileResolve.data);
+      })
+      .catch(() => {
+        window.location.href = 'http://localhost:8000';
+      });
   }, []);
 
   return (

--- a/Frontend/Views/Components/NewIssueOption.js
+++ b/Frontend/Views/Components/NewIssueOption.js
@@ -23,16 +23,14 @@ const NewIssueOption = ({
     const labelProm = axios.get(LABEL_URL, { withCredentials: true });
     const mileProm = axios.get(MILE_URL, { withCredentials: true });
 
-    await Promise.all([userProm, labelProm, mileProm])
-      .then((resolve) => {
-        const [userResolve, labelResolve, mileResolve] = resolve;
-        setUser(userResolve.data);
-        setLabel(labelResolve.data);
-        setMile(mileResolve.data);
-      })
-      .catch(() => {
-        window.location.href = 'http://localhost:8000';
-      });
+    try {
+      const [userResolve, labelResolve, mileResolve] = await Promise.all([userProm, labelProm, mileProm]);
+      setUser(userResolve.data);
+      setLabel(labelResolve.data);
+      setMile(mileResolve.data);
+    } catch (err) {
+      window.location.href = 'http://localhost:8000';
+    }
   }, []);
 
   return (

--- a/Frontend/Views/Pages/IssuesPage.js
+++ b/Frontend/Views/Pages/IssuesPage.js
@@ -25,19 +25,23 @@ const IssuesPage = () => {
     const labelProm = axios.get(LABEL_URL, { withCredentials: true });
     const mileProm = axios.get(MILE_URL, { withCredentials: true });
 
-    await Promise.all([issueProm, userProm, labelProm, mileProm])
-      .then((resolve) => {
-        const [issueResolve, userResolve, labelResolve, milesResolve] = resolve;
-        setData({
-          issueData: issueResolve.data,
-          userData: toKeyValueMap(userResolve.data),
-          labelData: toKeyValueMap(labelResolve.data),
-          mileData: toKeyValueMap(milesResolve.data),
-        });
-      })
-      .catch(() => {
-        window.location.href = 'http://localhost:8000';
+    try {
+      const [issueResolve, userResolve, labelResolve, milesResolve] = await Promise.all([
+        issueProm,
+        userProm,
+        labelProm,
+        mileProm,
+      ]);
+
+      setData({
+        issueData: issueResolve.data,
+        userData: toKeyValueMap(userResolve.data),
+        labelData: toKeyValueMap(labelResolve.data),
+        mileData: toKeyValueMap(milesResolve.data),
       });
+    } catch (err) {
+      window.location.href = 'http://localhost:8000';
+    }
   }, []);
 
   return (

--- a/Frontend/Views/Pages/IssuesPage.js
+++ b/Frontend/Views/Pages/IssuesPage.js
@@ -20,24 +20,24 @@ const IssuesPage = () => {
     const LABEL_URL = 'http://localhost:3000/api/v1/labels';
     const MILE_URL = 'http://localhost:3000/api/v1/milestones';
 
-    const issueProm = axios.get(ISSUE_URL);
-    const userProm = axios.get(USER_URL);
-    const labelProm = axios.get(LABEL_URL);
-    const mileProm = axios.get(MILE_URL);
+    const issueProm = axios.get(ISSUE_URL, { withCredentials: true });
+    const userProm = axios.get(USER_URL, { withCredentials: true });
+    const labelProm = axios.get(LABEL_URL, { withCredentials: true });
+    const mileProm = axios.get(MILE_URL, { withCredentials: true });
 
-    const [issueResolve, userResolve, labelResolve, milesResolve] = await Promise.all([
-      issueProm,
-      userProm,
-      labelProm,
-      mileProm,
-    ]);
-
-    setData({
-      issueData: issueResolve.data,
-      userData: toKeyValueMap(userResolve.data),
-      labelData: toKeyValueMap(labelResolve.data),
-      mileData: toKeyValueMap(milesResolve.data),
-    });
+    await Promise.all([issueProm, userProm, labelProm, mileProm])
+      .then((resolve) => {
+        const [issueResolve, userResolve, labelResolve, milesResolve] = resolve;
+        setData({
+          issueData: issueResolve.data,
+          userData: toKeyValueMap(userResolve.data),
+          labelData: toKeyValueMap(labelResolve.data),
+          mileData: toKeyValueMap(milesResolve.data),
+        });
+      })
+      .catch(() => {
+        window.location.href = 'http://localhost:8000';
+      });
   }, []);
 
   return (

--- a/Frontend/Views/Pages/LoginPage.js
+++ b/Frontend/Views/Pages/LoginPage.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+const LoginPage = () => {
+  const githubOauth = () => {
+    console.log('가자 깃헙으로');
+    location.href = 'http://localhost:3000/auth/github';
+  };
+  return (
+    <div>
+      <div>
+        <div>
+          <span>ID: </span>
+          <input type="text" />
+        </div>
+        <div>
+          <span>PWD: </span>
+          <input type="password" />
+        </div>
+      </div>
+      <div>
+        <button type="button" onClick={githubOauth}>
+          GitHub으로 로그인하기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/Frontend/Views/Pages/LoginPage.js
+++ b/Frontend/Views/Pages/LoginPage.js
@@ -2,9 +2,9 @@ import React from 'react';
 
 const LoginPage = () => {
   const githubOauth = () => {
-    console.log('가자 깃헙으로');
-    location.href = 'http://localhost:3000/auth/github';
+    window.location.href = 'http://localhost:3000/auth/github';
   };
+
   return (
     <div>
       <div>


### PR DESCRIPTION
[comment]: <> (PR 태그를 명시해주세요. [ADD] / [UPDATE] / [BUG])

### 요약
passport-github, jwt를 이용하여 OAuth 구현, 모든 요청에 대해 인증 확인

### 핵심 로직 및 내용

#### OAuth 구현
- passport-github 구현, 로그인 유지는 jsonwebtoken을 이용함 
- github 인증이 완료되면 cookie에 token을 발행
- CORS를 위해(쿠키를 공유하기위해), client가 axios요청 시 {withCredentials:true} 옵션 삽입
- 서버측에서도 cors를 열어둬야함(이미 설정되어 있었음)

<br>

#### 로직 및 코드 변경사항

- 모든 요청에 대해 먼저, token 검증을 함
- token 검증이 성공하면, 라우터에게 request를 넘김
- token 검증이 실패하면 401 status를 반환 
- client측에서 401에러를 받으면, 로그인 화면으로 돌아가게끔 설정
    - **이를 위해, promise 부분을 then, catch로 변경했습니다.** 
    - 401 에러를 반환하면, promise에 어떤 값도 안담기고 프로그램이 죽더라구요..

<br>


#### 파일구조

- local 전략 확장을 위해서 passport 디렉토리 생성 
- passport디렉토리에 index.js에서 각 전략을 config함 

### 기타 참고 사항
오프라인 만남 매우 시급

## 이미지 보내는 부분은 함부로 건드리면 안될 것 같아서, catch, then으로 변경 안했습니당. 나중에 같이 ㄱㄱ
