### PR TITLE
[ADD] comment 수정 기능 추가 

### DIFF
--- a/Backend/Routes/commentRoute.js
+++ b/Backend/Routes/commentRoute.js
@@ -21,4 +21,15 @@ router.post('/', async (req, res) => {
   }
 });
 
+router.patch('/:commentId', async (req, res) => {
+  const { description } = req.body;
+  const { commentId } = req.params;
+  try {
+    const [result] = await db.execute('UPDATE comments SET description = ? WHERE id = ?', [description, commentId]);
+    res.status(200).json({ result });
+  } catch (err) {
+    res.status(400).end();
+  }
+});
+
 module.exports = router;

--- a/Frontend/Views/Components/CommentForm.js
+++ b/Frontend/Views/Components/CommentForm.js
@@ -2,8 +2,17 @@ import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import ErrorMessage from './ErrorMessage';
 
-const CommentForm = ({ issueId, commentsData, setCommentsData }) => {
-  const [comment, setComment] = useState('');
+const CommentForm = ({
+  issueId,
+  commentsData,
+  setCommentsData,
+  description,
+  setDescription,
+  setIsDescription,
+  isEdit,
+  commentId,
+}) => {
+  const [comment, setComment] = useState(description);
   const [commentError, setCommentError] = useState(false);
   const [imageError, setImageError] = useState(false);
   const [submitDisabled, setSubmitDisabled] = useState(true);
@@ -30,10 +39,30 @@ const CommentForm = ({ issueId, commentsData, setCommentsData }) => {
     }
   };
 
+  const patchComment = async () => {
+    try {
+      return await axios.patch(
+        `http://localhost:3000/api/v1/comments/${commentId}`,
+        {
+          description: comment,
+        },
+        { withCredentials: true },
+      );
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
   const createComment = async () => {
     const result = await postComment();
     const [newComment] = result.data.comment;
     setCommentsData([...commentsData, newComment]);
+  };
+
+  const editComment = async () => {
+    const result = await patchComment();
+    setDescription(comment);
+    setIsDescription(true);
   };
 
   const onSubmitComment = (e) => {
@@ -47,7 +76,7 @@ const CommentForm = ({ issueId, commentsData, setCommentsData }) => {
       return;
     }
     e.preventDefault();
-    createComment();
+    (isEdit ? editComment : createComment)();
   };
 
   const onChangeComment = (e) => {
@@ -74,6 +103,10 @@ const CommentForm = ({ issueId, commentsData, setCommentsData }) => {
     }
   };
 
+  const onClickCancel = () => {
+    if (isEdit) setIsDescription(true);
+  };
+
   return (
     <>
       <textarea type="text" placeholder="Leave a comment" onChange={onChangeComment} value={comment} />
@@ -85,9 +118,11 @@ const CommentForm = ({ issueId, commentsData, setCommentsData }) => {
       />
       {commentError && <ErrorMessage message="본문을 입력해주세요." />}
       {imageError && <ErrorMessage message="이미지 업로드에 실패했습니다." />}
-      <button type="button">Close issue</button>
+      <button type="button" onClick={onClickCancel}>
+        {isEdit ? 'Cancel' : 'Close issue'}
+      </button>
       <button type="submit" onClick={onSubmitComment} disabled={submitDisabled}>
-        Comment
+        {isEdit ? 'Updatae Comment' : 'Comment'}
       </button>
     </>
   );

--- a/Frontend/Views/Components/CommentForm.js
+++ b/Frontend/Views/Components/CommentForm.js
@@ -122,7 +122,7 @@ const CommentForm = ({
         {isEdit ? 'Cancel' : 'Close issue'}
       </button>
       <button type="submit" onClick={onSubmitComment} disabled={submitDisabled}>
-        {isEdit ? 'Updatae Comment' : 'Comment'}
+        {isEdit ? 'Update comment' : 'Comment'}
       </button>
     </>
   );

--- a/Frontend/Views/Components/CommentList.js
+++ b/Frontend/Views/Components/CommentList.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import Comment from './Comment';
+import CommentWrapper from './CommentWrapper';
 
 const CommentList = ({ commentsData, owner }) => {
   return (
     <>
       {commentsData.map((comment) => (
-        <Comment key={comment.id} description={comment.description} isOwner={owner === comment.userId} />
+        <CommentWrapper key={comment.id} comment={comment} isOwner={owner === comment.userId} />
       ))}
     </>
   );

--- a/Frontend/Views/Components/CommentWrapper.js
+++ b/Frontend/Views/Components/CommentWrapper.js
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import Comment from './Comment';
+import CommentForm from './CommentForm';
+
+const CommentWrapper = ({ comment, isOwner }) => {
+  const [description, setDescription] = useState(comment.description);
+  const [isDescription, setIsDescription] = useState(true);
+
+  const onClickEdit = () => {
+    setIsDescription(false);
+  };
+
+  return (
+    <>
+      <button type="button" onClick={onClickEdit}>
+        edit
+      </button>
+      {isDescription ? (
+        <Comment description={description} />
+      ) : (
+        <CommentForm
+          description={description}
+          setDescription={setDescription}
+          setIsDescription={setIsDescription}
+          isEdit
+          commentId={comment.id}
+        />
+      )}
+    </>
+  );
+};
+
+export default CommentWrapper;


### PR DESCRIPTION
[comment]: <> (PR 태그를 명시해주세요. [ADD] / [UPDATE] / [BUG])

### 요약

comment detail 페이지의 comment 수정 기능 추가했습니다. 

### 핵심 로직 및 내용

**Frontend**

- `Comment`컴포넌트와 `CommentForm` 컴포넌트을 `CommentWrapper`의 `isDescription`의 상태에 따라 랜더링되도록 했습니다. 
- comment를 추가하는데 사용했던 `CommentForm`을 comment를 수정할 때도 사용하도록 했습니다. 
  - `create`인지 `edit`인지 파악하기 위한 분기를 추가했습니다. 

**Backend**

- comment 수정에 사용할 API를 추가했습니다. 

### 기타 참고 사항

서버에서 `status`만 넘기면 제대로 response가 넘어가지 않는것이였군요...
