### PR TITLE
[UDDATE] 유저정보 DB 삽입 기능, 및 검증 단계 추가

### DIFF
--- a/Backend/Passport/github.js
+++ b/Backend/Passport/github.js
@@ -1,5 +1,6 @@
 const passport = require('passport');
 const GithubStrategy = require('passport-github').Strategy;
+const { db } = require('../Models/dbPool');
 
 module.exports = () => {
   passport.use(
@@ -10,8 +11,21 @@ module.exports = () => {
         callbackURL: 'http://localhost:3000/auth/github/callback',
       },
 
-      (accessToken, refreshToken, profile, done) => {
-        return done(null, { username: profile.username, imgUrl: profile._json.avatar_url });
+      async (accessToken, refreshToken, profile, done) => {
+        try {
+          const userValues = [profile.username, 'OAUTH_GITHUB', profile._json.avatar_url];
+          const insertSql = `INSERT INTO users(username,password,imageLink) Values(?,?,?)`;
+          await db.execute(insertSql, userValues);
+        } catch (err) {
+          if (err.errno !== 1062) {
+            //unique value duplication error
+            done(err);
+          }
+        }
+
+        const selectSql = `SELECT id,username,imageLink FROM users WHERE username='${profile.username}'`;
+        const [[{ id, username, imageLink }]] = await db.execute(selectSql);
+        return done(null, { userId: id, username: username, imageLink: imageLink });
       },
     ),
   );

--- a/Backend/Passport/token.js
+++ b/Backend/Passport/token.js
@@ -1,11 +1,19 @@
 const jwt = require('jsonwebtoken');
+const { db } = require('../Models/dbPool');
 
-exports.tokenCheck = (req, res, next) => {
+exports.tokenCheck = async (req, res, next) => {
   try {
-    const cookie = req.cookies.jwt;
-    jwt.verify(cookie, process.env.TOKEN_SECRET_KEY);
+    const decodedToken = jwt.verify(req.cookies.jwt, process.env.TOKEN_SECRET_KEY);
+    const selectSql = `SELECT id,username,imageLink FROM users WHERE id='${decodedToken.userId}'`;
+    const [[result]] = await db.execute(selectSql);
+
+    if (!result) {
+      throw new Error('cannot find user at Database');
+    }
+    req.user = result;
     next();
   } catch (err) {
+    console.log(err);
     // res.status(401).json();
     res.redirect('http://localhost:8000');
   }

--- a/Backend/Passport/token.js
+++ b/Backend/Passport/token.js
@@ -14,7 +14,6 @@ exports.tokenCheck = async (req, res, next) => {
     next();
   } catch (err) {
     console.log(err);
-    // res.status(401).json();
     res.redirect('http://localhost:8000');
   }
 };


### PR DESCRIPTION
[comment]: <> (PR 태그를 명시해주세요. [ADD] / [UPDATE] / [BUG])

### 요약
OAUTH 단계에서 받아온 계정 DB에 삽입, 검증 단계 추가

### 핵심 로직 및 내용
<로그인 단계>
Github에서 계정을 받아오면, db에 insert 쿼리 날림 
insert 단계에서 1026에러가 발생하면 중복된 아이디가 db에 존재한다는 의미, (아무런 에러도 발생 안하면, 최초 로그인)
1026에러가 아닌 다른 에러가 발생하면 done(err)
select 쿼리를 통해, 유저 정보를 db에서 받아온다.
유저정보를 tokenizing 하여 res.cookie에 담아서 응답

<br>

<검증 단계>
기존에는 jwt.verify를 통해 토큰이 타당한지 검사했다.
user database에 등록 안된 유저의 경우, jwt가 타당하면 로그인 단계가 통과되는 상황
jwt 타당성 검사 이후, db에 user가 존재하는지 확인하는 단계 추가.


### 기타 참고 사항
