### PR TITLE
[ADD] 이슈 정보 수정 API 추가 

### DIFF
--- a/Backend/Routes/commentRoute.js
+++ b/Backend/Routes/commentRoute.js
@@ -7,12 +7,12 @@ router.post('/', async (req, res) => {
   try {
     await conn.beginTransaction();
     const commentValues = [userId, issueId, description];
-    const [result] = await db.execute(
+    const [result] = await conn.execute(
       'INSERT INTO comments(userId, issueId, description) VALUES(?, ?, ?)',
       commentValues,
     );
     const { insertId } = result;
-    const [comment] = await db.execute('SELECT * FROM comments WHERE id = ? ORDER BY createdAt ASC', [insertId]);
+    const [comment] = await conn.execute('SELECT * FROM comments WHERE id = ?', [insertId]);
     await conn.commit();
     res.status(200).json({ comment });
   } catch (err) {

--- a/Backend/Routes/commentRoute.js
+++ b/Backend/Routes/commentRoute.js
@@ -18,6 +18,8 @@ router.post('/', async (req, res) => {
   } catch (err) {
     await conn.rollback();
     res.status(400).end();
+  } finally {
+    conn.release();
   }
 });
 

--- a/Backend/Routes/issueRoute.js
+++ b/Backend/Routes/issueRoute.js
@@ -174,6 +174,8 @@ router.patch('/:issueId/labels', async (req, res) => {
   } catch (err) {
     await conn.rollback();
     res.status(400).end();
+  } finally {
+    conn.release();
   }
 });
 
@@ -195,6 +197,8 @@ router.patch('/:issueId/assignees', async (req, res) => {
   } catch (err) {
     await conn.rollback();
     res.status(400).end();
+  } finally {
+    conn.release();
   }
 });
 

--- a/Backend/Routes/issueRoute.js
+++ b/Backend/Routes/issueRoute.js
@@ -134,4 +134,68 @@ router.get('/:issueId/comments', async (req, res) => {
   }
 });
 
+router.patch('/:issueId/title', async (req, res) => {
+  const { title } = req.body;
+  const { issueId } = req.params;
+  try {
+    const [result] = await db.execute('UPDATE issues SET title = ? WHERE id = ?', [title, issueId]);
+    res.status(200).json({ result });
+  } catch (err) {
+    res.status(400).end();
+  }
+});
+
+router.patch('/:issueId/milestone', async (req, res) => {
+  const { milestone } = req.body;
+  const { issueId } = req.params;
+  try {
+    const [result] = await db.execute('UPDATE issues SET milestone = ? WHERE id = ?', [milestone, issueId]);
+    res.status(200).json({ result });
+  } catch (err) {
+    res.status(400).end();
+  }
+});
+
+router.patch('/:issueId/labels', async (req, res) => {
+  const { labels } = req.body;
+  const { issueId } = req.params;
+
+  const conn = await db.getConnection();
+  try {
+    await conn.beginTransaction();
+    await conn.execute('DELETE FROM labelIssue WHERE issueId = ?', [issueId]);
+    await labels.reduce(async (lastPromise, label) => {
+      await lastPromise;
+      const labelQuery = `INSERT INTO labelIssue(labelId, issueId) VALUES(${label}, ${issueId})`;
+      await conn.query(labelQuery);
+    }, Promise.resolve());
+    await conn.commit();
+    res.status(200).json({ result: true });
+  } catch (err) {
+    await conn.rollback();
+    res.status(400).end();
+  }
+});
+
+router.patch('/:issueId/assignees', async (req, res) => {
+  const { assignees } = req.body;
+  const { issueId } = req.params;
+
+  const conn = await db.getConnection();
+  try {
+    await conn.beginTransaction();
+    await conn.execute('DELETE FROM assignees WHERE issueId = ?', [issueId]);
+    await assignees.reduce(async (lastPromise, assignee) => {
+      await lastPromise;
+      const assigneeQuery = `INSERT INTO assignees(assigneeId, issueId) VALUES(${assignee}, ${issueId})`;
+      await conn.query(assigneeQuery);
+    }, Promise.resolve());
+    await conn.commit();
+    res.status(200).json({ result: true });
+  } catch (err) {
+    await conn.rollback();
+    res.status(400).end();
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
[comment]: <> (PR 태그를 명시해주세요. [ADD] / [UPDATE] / [BUG])

### 요약

이슈 제목, 담당자, 라벨, 마일스톤을 수정할 수 있는 API를 추가했습니다. 

### 핵심 로직 및 내용

- 제목과 마일스톤은 `UPDATE`를 이용해 수정합니다. 
- 담당자와 라벨은 원래 있던 관계 데이터를 지우고 새로 추가하는 방식으로 수정합니다. 
- `commentRoute`의 DB 연결을 `db`에서 `conn`으로 수정했습니다. 

### 기타 참고 사항

`label`과 `assignee` 추가를 `reduce`를 이용해 여러번 요청을 보내는 방식으로 기존에 구현했기 때문에 그대로 적용했습니다만...
`VALUES(a1, b), (a2, b), (a3, b)`로 한 번에 요청을 보내는 방식도 고려해 보면 좋을 것 같습니다. 
