### PR TITLE
[ADD] 이슈 리스트 페이지 상단 필터, 필터 초기화, 모달 기능 추가

### DIFF
--- a/Backend/Routes/issueRoute.js
+++ b/Backend/Routes/issueRoute.js
@@ -135,4 +135,16 @@ router.get('/:issueId/comments', async (req, res) => {
   }
 });
 
+router.patch('/:issueId/status', async (req, res) => {
+  try {
+    const { issueId } = req.params;
+    const { isOpen } = req.body;
+    const [{ affectedRows }] = await db.execute('UPDATE issues SET isOpen = ? WHERE id = ?', [isOpen, issueId]);
+    if (affectedRows !== 1) res.status(404).end();
+    else res.status(204).end();
+  } catch (err) {
+    res.status(400).end();
+  }
+});
+
 module.exports = router;

--- a/Backend/Routes/issueRoute.js
+++ b/Backend/Routes/issueRoute.js
@@ -104,6 +104,8 @@ router.post('/', async (req, res) => {
   } catch {
     console.log('error');
     await conn.rollback();
+  } finally {
+    await conn.release();
   }
 });
 

--- a/Frontend/Views/Components/IssueList.js
+++ b/Frontend/Views/Components/IssueList.js
@@ -8,7 +8,7 @@ const getUserId = (cookie) => {
   return userId;
 };
 
-const TopFilter = ({ reloadIssue }) => {
+const TopFilter = ({ reloadIssue, setResetQuery }) => {
   const [isVisible, setIsVisible] = useState(false);
 
   const domNode = useClickOutside(() => {
@@ -22,6 +22,7 @@ const TopFilter = ({ reloadIssue }) => {
   const onClickFilter = (queryString) => {
     window.history.pushState({}, '', `/issues?${queryString}`);
     onToggleDropdown();
+    setResetQuery(true);
     reloadIssue();
   };
 
@@ -332,7 +333,7 @@ const IssueList = ({ issues, users, labels, milestones, reloadIssue }) => {
 
   return (
     <div>
-      <TopFilter reloadIssue={reloadIssue} />
+      <TopFilter reloadIssue={reloadIssue} setResetQuery={setResetQuery} />
       {resetQuery && (
         <button type="button" onClick={onClickReset}>
           Clear current search query, filters, and sorts

--- a/Frontend/Views/Components/IssueList.js
+++ b/Frontend/Views/Components/IssueList.js
@@ -1,10 +1,38 @@
 import React, { useEffect, useState, useRef } from 'react';
 import useClickOutside from './Modal';
 
-const MarkAs = () => {
+const MarkAsList = () => {
+  const onClickOpen = null;
+  const onClickClosed = null;
+
   return (
     <>
-      <button type="button">Mark as</button>
+      <div>Actions</div>
+      <div onClick={onClickOpen}>Open</div>
+      <div onClick={onClickClosed}>Closed</div>
+    </>
+  );
+};
+
+const MarkAs = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const domNode = useClickOutside(() => {
+    setIsVisible(false);
+  });
+
+  const onToggleDropdown = () => {
+    setIsVisible(!isVisible);
+  };
+
+  return (
+    <>
+      <div ref={domNode}>
+        <button type="button" onClick={onToggleDropdown}>
+          Mark as
+        </button>
+        {isVisible && <MarkAsList />}
+      </div>
     </>
   );
 };

--- a/Frontend/Views/Components/IssueList.js
+++ b/Frontend/Views/Components/IssueList.js
@@ -1,20 +1,34 @@
 import React, { useEffect, useState, useRef } from 'react';
+import axios from 'axios';
 import useClickOutside from './Modal';
 
-const MarkAsList = () => {
-  const onClickOpen = null;
-  const onClickClosed = null;
+const MarkAsList = ({ checkedIssues }) => {
+  const onChangeStatus = async (status) => {
+    try {
+      await axios.patch(
+        'http://localhost:3000/api/v1/issues/status',
+        {
+          issues: checkedIssues,
+          isOpen: status,
+        },
+        { withCredentials: true },
+      );
+      // window.location.reload();
+    } catch (err) {
+      console.log('error');
+    }
+  };
 
   return (
     <>
       <div>Actions</div>
-      <div onClick={onClickOpen}>Open</div>
-      <div onClick={onClickClosed}>Closed</div>
+      <div onClick={() => onChangeStatus(1)}>Open</div>
+      <div onClick={() => onChangeStatus(0)}>Closed</div>
     </>
   );
 };
 
-const MarkAs = () => {
+const MarkAs = ({ checkedIssues }) => {
   const [isVisible, setIsVisible] = useState(false);
 
   const domNode = useClickOutside(() => {
@@ -31,7 +45,7 @@ const MarkAs = () => {
         <button type="button" onClick={onToggleDropdown}>
           Mark as
         </button>
-        {isVisible && <MarkAsList />}
+        {isVisible && <MarkAsList checkedIssues={checkedIssues} />}
       </div>
     </>
   );
@@ -254,7 +268,7 @@ const IssueList = ({ issues, users, labels, milestones }) => {
   return (
     <div>
       <input type="checkbox" onChange={onCheckAll} checked={allChecked} />
-      {isMarkAs && <MarkAs />}
+      {isMarkAs && <MarkAs checkedIssues={checkedIssues} />}
       {!isMarkAs && <Alma users={users} labels={labels} milestones={milestones} />}
       {issues.map((issue) => (
         <IssueListItem

--- a/Frontend/Views/Components/IssueList.js
+++ b/Frontend/Views/Components/IssueList.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 
 const MarkAs = () => {
   return (
@@ -35,13 +35,7 @@ const MilestoneItem = ({ value }) => {
   );
 };
 
-const Dropdown = ({ name, values }) => {
-  const [isVisible, setIsVisible] = useState(false);
-
-  const onToggleDropdown = () => {
-    setIsVisible(!isVisible);
-  };
-
+const ChoiceList = ({ name, values }) => {
   let ItemComponent;
   switch (name) {
     case 'author':
@@ -84,22 +78,48 @@ const Dropdown = ({ name, values }) => {
 
   return (
     <>
-      <button type="button" onClick={onToggleDropdown}>
-        {name}
-      </button>
-      {isVisible && (
-        <>
-          <div>{`Filter by ${name}`}</div>
-          {Object.keys(values).map((key) => {
-            return (
-              <div key={key} onClick={() => onSelectAlmaItem(key)}>
-                <span>@</span>
-                <ItemComponent value={values[key]} />
-              </div>
-            );
-          })}
-        </>
-      )}
+      <div>{`Filter by ${name}`}</div>
+      {Object.keys(values).map((key) => {
+        return (
+          <div key={key} onClick={() => onSelectAlmaItem(key)}>
+            <span>@</span>
+            <ItemComponent value={values[key]} />
+          </div>
+        );
+      })}
+    </>
+  );
+};
+
+const Dropdown = ({ name, values }) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const choiceListRef = useRef();
+
+  useEffect(() => {
+    const closeModal = (e) => {
+      if (choiceListRef.current && !choiceListRef.current.contains(e.target)) {
+        setIsVisible(false);
+      }
+    };
+    document.addEventListener('mousedown', closeModal);
+    return () => {
+      document.removeEventListener('mousedown', closeModal);
+    };
+  });
+
+  const onToggleDropdown = () => {
+    setIsVisible(!isVisible);
+  };
+
+  return (
+    <>
+      <div ref={choiceListRef}>
+        <button type="button" onClick={onToggleDropdown}>
+          {name}
+        </button>
+        {isVisible && <ChoiceList name={name} values={values} />}
+      </div>
     </>
   );
 };

--- a/Frontend/Views/Components/IssueList.js
+++ b/Frontend/Views/Components/IssueList.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
+import useClickOutside from './Modal';
 
 const MarkAs = () => {
   return (
@@ -94,18 +95,8 @@ const ChoiceList = ({ name, values }) => {
 const Dropdown = ({ name, values }) => {
   const [isVisible, setIsVisible] = useState(false);
 
-  const choiceListRef = useRef();
-
-  useEffect(() => {
-    const closeModal = (e) => {
-      if (choiceListRef.current && !choiceListRef.current.contains(e.target)) {
-        setIsVisible(false);
-      }
-    };
-    document.addEventListener('mousedown', closeModal);
-    return () => {
-      document.removeEventListener('mousedown', closeModal);
-    };
+  const domNode = useClickOutside(() => {
+    setIsVisible(false);
   });
 
   const onToggleDropdown = () => {
@@ -114,7 +105,7 @@ const Dropdown = ({ name, values }) => {
 
   return (
     <>
-      <div ref={choiceListRef}>
+      <div ref={domNode}>
         <button type="button" onClick={onToggleDropdown}>
           {name}
         </button>

--- a/Frontend/Views/Components/IssueList.js
+++ b/Frontend/Views/Components/IssueList.js
@@ -296,8 +296,7 @@ const IssueList = ({ issues, users, labels, milestones, reloadIssue }) => {
   const [isCheckAll, setIsCheckAll] = useState(false);
   const [allChecked, setAllChecked] = useState(false);
   const [isMarkAs, setIsMarkAs] = useState(false);
-
-  const [resetQuery, setResetQuery] = useState(false);
+  const [resetQuery, setResetQuery] = useState(window.location.search !== '');
 
   useEffect(() => {
     if (checkedIssues.length === 0) {

--- a/Frontend/Views/Components/IssueList.js
+++ b/Frontend/Views/Components/IssueList.js
@@ -30,10 +30,9 @@ const TopFilter = ({ reloadIssue }) => {
       <>
         <div>Filter Issues</div>
         <div onClick={() => onClickFilter('open=1')}>Open Issues</div>
-        {/* TODO: 본인 id로 넘겨주는건지 백에서 처리하는 건지 */}
         <div onClick={() => onClickFilter(`author=${getUserId(document.cookie)}`)}>Your Issues</div>
         <div onClick={() => onClickFilter(`assignee=${getUserId(document.cookie)}`)}>Everything assigned to you</div>
-        <div onClick={() => onClickFilter()}>Everything mentioning you</div>
+        <div onClick={() => onClickFilter(`mentions=${getUserId(document.cookie)}`)}>Everything mentioning you</div>
         <div onClick={() => onClickFilter('open=0')}>Closed Issues</div>
       </>
     );

--- a/Frontend/Views/Components/IssueList.js
+++ b/Frontend/Views/Components/IssueList.js
@@ -324,7 +324,6 @@ const IssueList = ({ issues, users, labels, milestones, reloadIssue }) => {
     }
   };
 
-  // TODO: 최초 진입이 쿼리스트링일 때는 resetQuery가 true여야 함.
   const onClickReset = () => {
     setResetQuery(false);
     window.history.pushState({}, '', `/issues`);

--- a/Frontend/Views/Components/IssueList.js
+++ b/Frontend/Views/Components/IssueList.js
@@ -2,6 +2,12 @@ import React, { useEffect, useState, useRef } from 'react';
 import axios from 'axios';
 import useClickOutside from './Modal';
 
+const getUserId = (cookie) => {
+  const token = cookie.split('=')[1].split('.');
+  const { userId } = JSON.parse(window.atob(token[1]));
+  return userId;
+};
+
 const TopFilter = ({ reloadIssue }) => {
   const [isVisible, setIsVisible] = useState(false);
 
@@ -25,17 +31,8 @@ const TopFilter = ({ reloadIssue }) => {
         <div>Filter Issues</div>
         <div onClick={() => onClickFilter('open=1')}>Open Issues</div>
         {/* TODO: 본인 id로 넘겨주는건지 백에서 처리하는 건지 */}
-        <div
-          onClick={() => {
-            const token = document.cookie.split('=')[1].split('.');
-            // const newToken = token.map((t) => console.log(t));
-            console.log(window.atob(token[1]));
-            // console.log(token.length);
-          }}
-        >
-          Your Issues
-        </div>
-        <div onClick={() => onClickFilter()}>Everything assigned to you</div>
+        <div onClick={() => onClickFilter(`author=${getUserId(document.cookie)}`)}>Your Issues</div>
+        <div onClick={() => onClickFilter(`assignee=${getUserId(document.cookie)}`)}>Everything assigned to you</div>
         <div onClick={() => onClickFilter()}>Everything mentioning you</div>
         <div onClick={() => onClickFilter('open=0')}>Closed Issues</div>
       </>

--- a/Frontend/Views/Components/IssueList.js
+++ b/Frontend/Views/Components/IssueList.js
@@ -2,6 +2,59 @@ import React, { useEffect, useState, useRef } from 'react';
 import axios from 'axios';
 import useClickOutside from './Modal';
 
+const TopFilter = ({ reloadIssue }) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const domNode = useClickOutside(() => {
+    setIsVisible(false);
+  });
+
+  const onToggleDropdown = () => {
+    setIsVisible(!isVisible);
+  };
+
+  const onClickFilter = (queryString) => {
+    window.history.pushState({}, '', `/issues?${queryString}`);
+    onToggleDropdown();
+    reloadIssue();
+  };
+
+  const TopFilterMenu = () => {
+    return (
+      <>
+        <div>Filter Issues</div>
+        <div onClick={() => onClickFilter('open=1')}>Open Issues</div>
+        {/* TODO: 본인 id로 넘겨주는건지 백에서 처리하는 건지 */}
+        <div
+          onClick={() => {
+            const token = document.cookie.split('=')[1].split('.');
+            // const newToken = token.map((t) => console.log(t));
+            console.log(window.atob(token[1]));
+            // console.log(token.length);
+          }}
+        >
+          Your Issues
+        </div>
+        <div onClick={() => onClickFilter()}>Everything assigned to you</div>
+        <div onClick={() => onClickFilter()}>Everything mentioning you</div>
+        <div onClick={() => onClickFilter('open=0')}>Closed Issues</div>
+      </>
+    );
+  };
+
+  return (
+    <>
+      <div ref={domNode}>
+        <button type="button" onClick={onToggleDropdown}>
+          Filters
+        </button>
+        <input type="text" />
+        {isVisible && <TopFilterMenu />}
+      </div>
+    </>
+  );
+};
+
 const MarkAs = ({ checkedIssues, reloadIssue, setIsMarkAs }) => {
   const [isVisible, setIsVisible] = useState(false);
 
@@ -284,6 +337,7 @@ const IssueList = ({ issues, users, labels, milestones, reloadIssue }) => {
 
   return (
     <div>
+      <TopFilter reloadIssue={reloadIssue} />
       {resetQuery && (
         <button type="button" onClick={onClickReset}>
           Clear current search query, filters, and sorts

--- a/Frontend/Views/Components/IssueList.js
+++ b/Frontend/Views/Components/IssueList.js
@@ -80,7 +80,7 @@ const MilestoneItem = ({ value }) => {
   );
 };
 
-const ChoiceList = ({ name, values, reloadIssue, onToggleDropdown }) => {
+const ChoiceList = ({ name, values, reloadIssue, onToggleDropdown, setResetQuery }) => {
   let ItemComponent;
   switch (name) {
     case 'author':
@@ -120,6 +120,7 @@ const ChoiceList = ({ name, values, reloadIssue, onToggleDropdown }) => {
     }, '');
     window.history.pushState({}, '', `/issues?${newQueryString}`);
     onToggleDropdown();
+    setResetQuery(true);
     reloadIssue();
   };
 
@@ -138,7 +139,7 @@ const ChoiceList = ({ name, values, reloadIssue, onToggleDropdown }) => {
   );
 };
 
-const Dropdown = ({ name, values, reloadIssue }) => {
+const Dropdown = ({ name, values, reloadIssue, setResetQuery }) => {
   const [isVisible, setIsVisible] = useState(false);
 
   const domNode = useClickOutside(() => {
@@ -156,20 +157,26 @@ const Dropdown = ({ name, values, reloadIssue }) => {
           {name}
         </button>
         {isVisible && (
-          <ChoiceList name={name} values={values} reloadIssue={reloadIssue} onToggleDropdown={onToggleDropdown} />
+          <ChoiceList
+            name={name}
+            values={values}
+            reloadIssue={reloadIssue}
+            onToggleDropdown={onToggleDropdown}
+            setResetQuery={setResetQuery}
+          />
         )}
       </div>
     </>
   );
 };
 
-const Alma = ({ users, labels, milestones, reloadIssue }) => {
+const Alma = ({ users, labels, milestones, reloadIssue, setResetQuery }) => {
   return (
     <>
-      <Dropdown name="author" values={users} reloadIssue={reloadIssue} />
-      <Dropdown name="label" values={labels} reloadIssue={reloadIssue} />
-      <Dropdown name="milestone" values={milestones} reloadIssue={reloadIssue} />
-      <Dropdown name="assignee" values={users} reloadIssue={reloadIssue} />
+      <Dropdown name="author" values={users} reloadIssue={reloadIssue} setResetQuery={setResetQuery} />
+      <Dropdown name="label" values={labels} reloadIssue={reloadIssue} setResetQuery={setResetQuery} />
+      <Dropdown name="milestone" values={milestones} reloadIssue={reloadIssue} setResetQuery={setResetQuery} />
+      <Dropdown name="assignee" values={users} reloadIssue={reloadIssue} setResetQuery={setResetQuery} />
     </>
   );
 };
@@ -241,6 +248,8 @@ const IssueList = ({ issues, users, labels, milestones, reloadIssue }) => {
   const [allChecked, setAllChecked] = useState(false);
   const [isMarkAs, setIsMarkAs] = useState(false);
 
+  const [resetQuery, setResetQuery] = useState(false);
+
   useEffect(() => {
     if (checkedIssues.length === 0) {
       setAllChecked(false);
@@ -266,11 +275,31 @@ const IssueList = ({ issues, users, labels, milestones, reloadIssue }) => {
     }
   };
 
+  // TODO: 최초 진입이 쿼리스트링일 때는 resetQuery가 true여야 함.
+  const onClickReset = () => {
+    setResetQuery(false);
+    window.history.pushState({}, '', `/issues`);
+    reloadIssue();
+  };
+
   return (
     <div>
+      {resetQuery && (
+        <button type="button" onClick={onClickReset}>
+          Clear current search query, filters, and sorts
+        </button>
+      )}
       <input type="checkbox" onChange={onCheckAll} checked={allChecked} />
       {isMarkAs && <MarkAs reloadIssue={reloadIssue} checkedIssues={checkedIssues} setIsMarkAs={setIsMarkAs} />}
-      {!isMarkAs && <Alma reloadIssue={reloadIssue} users={users} labels={labels} milestones={milestones} />}
+      {!isMarkAs && (
+        <Alma
+          reloadIssue={reloadIssue}
+          users={users}
+          labels={labels}
+          milestones={milestones}
+          setResetQuery={setResetQuery}
+        />
+      )}
       {issues.map((issue) => (
         <IssueListItem
           key={issue.id}

--- a/Frontend/Views/Components/Modal.js
+++ b/Frontend/Views/Components/Modal.js
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from 'react';
+
+const useClickOutside = (handler) => {
+  const domNode = useRef();
+  useEffect(() => {
+    const newHandler = (e) => {
+      if (domNode.current && !domNode.current.contains(e.target)) {
+        handler();
+      }
+    };
+    document.addEventListener('mousedown', newHandler);
+    return () => {
+      document.removeEventListener('mousedown', newHandler);
+    };
+  });
+
+  return domNode;
+};
+
+export default useClickOutside;

--- a/Frontend/Views/Pages/IssuesPage.js
+++ b/Frontend/Views/Pages/IssuesPage.js
@@ -15,12 +15,10 @@ const IssuesPage = () => {
   const [issueReload, setIssueReload] = useState(true);
 
   const reloadIssue = () => {
-    console.log('reloadIssue');
     setIssueReload(!issueReload);
   };
 
   useEffect(async () => {
-    console.log('hi');
     const ISSUE_URL = 'http://localhost:3000/api/v1/issues';
     const USER_URL = 'http://localhost:3000/api/v1/users';
     const LABEL_URL = 'http://localhost:3000/api/v1/labels';

--- a/Frontend/Views/Pages/IssuesPage.js
+++ b/Frontend/Views/Pages/IssuesPage.js
@@ -25,7 +25,6 @@ const IssuesPage = () => {
     const MILE_URL = 'http://localhost:3000/api/v1/milestones';
 
     const queryString = window.location.search;
-    console.log(queryString);
     const issueProm = axios.get(`${ISSUE_URL}${queryString}`, { withCredentials: true });
     const userProm = axios.get(USER_URL, { withCredentials: true });
     const labelProm = axios.get(LABEL_URL, { withCredentials: true });

--- a/Frontend/Views/Pages/IssuesPage.js
+++ b/Frontend/Views/Pages/IssuesPage.js
@@ -12,14 +12,22 @@ const toKeyValueMap = (records) => {
 
 const IssuesPage = () => {
   const [data, setData] = useState({ issueData: [], userData: [], labelData: [], mileData: [] });
+  const [issueReload, setIssueReload] = useState(true);
+
+  const reloadIssue = () => {
+    console.log('reloadIssue');
+    setIssueReload(!issueReload);
+  };
 
   useEffect(async () => {
+    console.log('hi');
     const ISSUE_URL = 'http://localhost:3000/api/v1/issues';
     const USER_URL = 'http://localhost:3000/api/v1/users';
     const LABEL_URL = 'http://localhost:3000/api/v1/labels';
     const MILE_URL = 'http://localhost:3000/api/v1/milestones';
 
     const queryString = window.location.search;
+    console.log(queryString);
     const issueProm = axios.get(`${ISSUE_URL}${queryString}`, { withCredentials: true });
     const userProm = axios.get(USER_URL, { withCredentials: true });
     const labelProm = axios.get(LABEL_URL, { withCredentials: true });
@@ -42,11 +50,17 @@ const IssuesPage = () => {
     } catch (err) {
       window.location.href = 'http://localhost:8000';
     }
-  }, []);
+  }, [issueReload]);
 
   return (
     <div>
-      <IssueList issues={data.issueData} users={data.userData} labels={data.labelData} milestones={data.mileData} />
+      <IssueList
+        issues={data.issueData}
+        users={data.userData}
+        labels={data.labelData}
+        milestones={data.mileData}
+        reloadIssue={reloadIssue}
+      />
     </div>
   );
 };


### PR DESCRIPTION
[comment]: <> (PR 태그를 명시해주세요. [ADD] / [UPDATE] / [BUG])

### 요약

1. 이슈 리스트 페이지에서 상단 필터(Filters)를 추가하고 필터링 기능을 추가했습니다.
2. 필터 적용 시 필터 초기화 버튼을 렌더링하고 이를 클릭할 시 필터를 초기화합니다.
3. 모달 기능을 추가하였습니다.

### 핵심 로직 및 내용

#### 상단 필터

상단 필터를 적용하면 `history.pushState` API를 사용하여 필터에 해당하는 쿼리스트링을 붙이고 이슈를 다시 렌더링합니다. 지금까지는 새로고침을 활용하여 필터가 적용된 이슈를 렌더링했는데, `IssuesPage`에 `useEffect`가 추적하는 값 `issueReload`를 추가하여 리렌더링이 필요할 때 이 값을 바꿔 새로고침 없이 렌더링을 할 수 있도록 합니다.

#### 필터 초기화

필터 초기화 버튼을 클릭하면 쿼리스트링을 비우고 이슈를 다시 렌더링합니다. 필터 초기화 버튼은 필터가 적용되어 있을 때(쿼리스트링이 있을 때)만 활성화됩니다. 

#### 모달

useRef를 사용하여 모달 영역을 지정하고, 이 외의 공간에 클릭 이벤트가 발생하는지에 대한 핸들러를 document.addEventListener를 이용하여 부착해줍니다. 이후 모달창이 꺼질 때마다 해당 이벤트리스너는 remove해줍니다.
이 부분은 별도의 파일인 Modal.js에 명시되어있고, 재사용이 가능합니다. 

### 기타 참고 사항

현재는 뒤로가기, 앞으로가기 버튼을 누르더라고 이전 필터가 적용되지는 않습니다. 이후 해당 기능을 구현할 예정입니다.
