### PR TITLE
[ADD] Open, Close 마일스톤 보여주기 & 마일스톤 Open/Close 상태 변경

### DIFF
--- a/Backend/Routes/milestoneRoute.js
+++ b/Backend/Routes/milestoneRoute.js
@@ -19,7 +19,7 @@ router.patch('/:milestoneId', async (req, res) => {
     setClause.push(`isOpen='${isOpen}'`);
   }
 
-  const query = `UPDATE milestones SET ${setClause.join(',')} WHERE id='${milestoneId[1]}'`;
+  const query = `UPDATE milestones SET ${setClause.join(',')} WHERE id='${milestoneId}'`;
   await db.execute(query);
   res.json({});
 });

--- a/Backend/Routes/milestoneRoute.js
+++ b/Backend/Routes/milestoneRoute.js
@@ -1,6 +1,29 @@
 const router = require('express').Router();
 const { db } = require('../Models/dbPool');
 
+router.patch('/:milestoneId', async (req, res) => {
+  const { title, dueDate, description, isOpen } = req.body;
+  const { milestoneId } = req.params;
+
+  const setClause = [];
+  if (title) {
+    setClause.push(`title='${title}'`);
+  }
+  if (dueDate) {
+    setClause.push(`dueDate='${dueDate}'`);
+  }
+  if (description) {
+    setClause.push(`description='${description}'`);
+  }
+  if (isOpen !== undefined) {
+    setClause.push(`isOpen='${isOpen}'`);
+  }
+
+  const query = `UPDATE milestones SET ${setClause.join(',')} WHERE id='${milestoneId[1]}'`;
+  await db.execute(query);
+  res.json({});
+});
+
 router.get('/count', async (req, res) => {
   const query = `
   SELECT mi.id, mi.isOpen as mileIsOpen, mi.dueDate, mi.description, mi.title, iss.isOpen as issueIsOpen, COUNT(iss.id) as cnt
@@ -21,7 +44,7 @@ router.get('/count', async (req, res) => {
       result[row.id] = {
         id: row.id,
         mileIsOpen: row.mileIsOpen,
-        dueData: row.dueDate,
+        dueDate: row.dueDate,
         description: row.description,
         title: row.title,
         total: row.cnt || 0,

--- a/Backend/Routes/milestoneRoute.js
+++ b/Backend/Routes/milestoneRoute.js
@@ -6,21 +6,26 @@ router.patch('/:milestoneId', async (req, res) => {
   const { milestoneId } = req.params;
 
   const setClause = [];
+  const values = [];
   if (title) {
-    setClause.push(`title='${title}'`);
+    setClause.push(`title=?`);
+    values.push(title);
   }
   if (dueDate) {
-    setClause.push(`dueDate='${dueDate}'`);
+    setClause.push(`dueDate=?`);
+    values.push(dueDate);
   }
   if (description) {
-    setClause.push(`description='${description}'`);
+    setClause.push(`description=?`);
+    values.push(description);
   }
   if (isOpen !== undefined) {
-    setClause.push(`isOpen='${isOpen}'`);
+    setClause.push(`isOpen=?`);
+    values.push(isOpen);
   }
-
-  const query = `UPDATE milestones SET ${setClause.join(',')} WHERE id='${milestoneId}'`;
-  await db.execute(query);
+  values.push(milestoneId);
+  const query = `UPDATE milestones SET ${setClause.join(',')} WHERE id=?`;
+  await db.execute(query, values);
   res.json({});
 });
 

--- a/Backend/Routes/milestoneRoute.js
+++ b/Backend/Routes/milestoneRoute.js
@@ -44,4 +44,11 @@ router.get('/', async (req, res) => {
   res.json(results[0]);
 });
 
+router.post('/', async (req, res) => {
+  const query = `INSERT INTO milestones(title, dueDate, description, isOpen) VALUES(?,?,?,?)`;
+  const { title, dueDate, description } = req.body;
+  await db.execute(query, [title, dueDate, description, 1]);
+  res.json({});
+});
+
 module.exports = router;

--- a/Frontend/Views/App.js
+++ b/Frontend/Views/App.js
@@ -7,6 +7,7 @@ import IssueDetailPage from './Pages/IssueDetailPage';
 import LoginPage from './Pages/LoginPage';
 import LabelPage from './Pages/LabelPage';
 import MilestonPage from './Pages/MilestonePage';
+import NewMilestonePage from './Pages/NewMilestonePage';
 
 const App = () => {
   return (
@@ -17,7 +18,10 @@ const App = () => {
         <Route exact path="/issues/new" component={NewIssuePage} />
         <Route exact path="/issues/:issueId" component={IssueDetailPage} />
       </Switch>
-      <Route exact path="/milestones" component={MilestonPage} />
+      <Switch>
+        <Route exact path="/milestones" component={MilestonPage} />
+        <Route exact path="/milestones/new" component={NewMilestonePage} />
+      </Switch>
       <Route exact path="/labels" component={LabelPage} />
     </Router>
   );

--- a/Frontend/Views/Components/Milestone.js
+++ b/Frontend/Views/Components/Milestone.js
@@ -2,7 +2,7 @@ import React from 'react';
 import axios from 'axios';
 
 const Milestone = ({ milestone }) => {
-  const MILE_URL = `http://localhost:3000/api/v1/milestones/:${milestone.id}`;
+  const MILE_URL = `http://localhost:3000/api/v1/milestones/${milestone.id}`;
 
   const box = {
     border: '1px solid',

--- a/Frontend/Views/Components/Milestone.js
+++ b/Frontend/Views/Components/Milestone.js
@@ -1,6 +1,9 @@
 import React from 'react';
+import axios from 'axios';
 
 const Milestone = ({ milestone }) => {
+  const MILE_URL = `http://localhost:3000/api/v1/milestones/:${milestone.id}`;
+
   const box = {
     border: '1px solid',
     width: '200px',
@@ -13,16 +16,39 @@ const Milestone = ({ milestone }) => {
     backgroundColor: 'gray',
   };
 
+  const onOpenCloseToggle = async () => {
+    const value = milestone.mileIsOpen ? 0 : 1;
+    try {
+      await axios.patch(MILE_URL, { isOpen: value }, { withCredentials: true });
+      window.location.href = 'http://localhost:8000/milestones';
+    } catch (err) {
+      window.location.href = 'http://localhost:8000';
+    }
+  };
+
+  const onEditBtn = async () => {};
+  const onDeleteBtn = async () => {};
+
   return (
-    <>
+    <div>
       <div>{`pk는 ${milestone.id} 제목은 ${milestone.title}`}</div>
       <div>{`전체 이슈: ${milestone.total} 열린 이슈:${milestone.opendIssue} 닫힌 이슈:${milestone.closedIssue}`}</div>
-      <div>{milestone.dueData}</div>
+      <div>{milestone.dueDate}</div>
       <div>{milestone.description}</div>
       <div style={box}>
         <div style={box2}> </div>
       </div>
-    </>
+
+      <button type="button" onClick={onOpenCloseToggle}>
+        {milestone.mileIsOpen ? <span>Close</span> : <span>Open</span>}
+      </button>
+      <button type="button" onClick={onEditBtn}>
+        Edit
+      </button>
+      <button type="button" onClick={onDeleteBtn}>
+        Delete
+      </button>
+    </div>
   );
 };
 

--- a/Frontend/Views/Pages/MilestonePage.js
+++ b/Frontend/Views/Pages/MilestonePage.js
@@ -17,10 +17,10 @@ const MilestonePage = () => {
     }
   }, []);
 
-  const openBtnClick = () => {
+  const onOpenBtnClick = () => {
     setWhichMile(1);
   };
-  const closeBtnClick = () => {
+  const onCloseBtnClick = () => {
     setWhichMile(0);
   };
 
@@ -30,10 +30,10 @@ const MilestonePage = () => {
       <Link to="/milestones">milestones</Link>
       <Link to="/milestones/new">new Milestone</Link>
 
-      <button type="button" onClick={openBtnClick}>
+      <button type="button" onClick={onOpenBtnClick}>
         Open
       </button>
-      <button type="button" onClick={closeBtnClick}>
+      <button type="button" onClick={onCloseBtnClick}>
         Close
       </button>
 

--- a/Frontend/Views/Pages/MilestonePage.js
+++ b/Frontend/Views/Pages/MilestonePage.js
@@ -20,6 +20,7 @@ const MilestonePage = () => {
     <div>
       <Link to="/labels">labels</Link>
       <Link to="/milestones">milestones</Link>
+      <Link to="/milestones/new">new Milestone</Link>
       {milestoneList.map((milestone) => (
         <Milestone key={milestone.id} milestone={milestone} />
       ))}

--- a/Frontend/Views/Pages/MilestonePage.js
+++ b/Frontend/Views/Pages/MilestonePage.js
@@ -5,6 +5,7 @@ import Milestone from '../Components/Milestone';
 
 const MilestonePage = () => {
   const [milestoneList, setMilestoneList] = useState([]);
+  const [whichMile, setWhichMile] = useState(1);
 
   useEffect(async () => {
     const MILE_URL = 'http://localhost:3000/api/v1/milestones/count';
@@ -16,14 +17,31 @@ const MilestonePage = () => {
     }
   }, []);
 
+  const openBtnClick = () => {
+    setWhichMile(1);
+  };
+  const closeBtnClick = () => {
+    setWhichMile(0);
+  };
+
   return (
     <div>
       <Link to="/labels">labels</Link>
       <Link to="/milestones">milestones</Link>
       <Link to="/milestones/new">new Milestone</Link>
-      {milestoneList.map((milestone) => (
-        <Milestone key={milestone.id} milestone={milestone} />
-      ))}
+
+      <button type="button" onClick={openBtnClick}>
+        Open
+      </button>
+      <button type="button" onClick={closeBtnClick}>
+        Close
+      </button>
+
+      {milestoneList
+        .filter((milestone) => milestone.mileIsOpen === whichMile)
+        .map((milestone) => (
+          <Milestone key={milestone.id} milestone={milestone} />
+        ))}
     </div>
   );
 };

--- a/Frontend/Views/Pages/NewMilestonePage.js
+++ b/Frontend/Views/Pages/NewMilestonePage.js
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+const NewMilestonePage = () => {
+  const [inputTitle, setTitle] = useState('');
+  const [inputDate, setDate] = useState('');
+  const [inputDescription, setDescription] = useState('');
+
+  const postMilestone = async () => {
+    const MILE_URL = 'http://localhost:3000/api/v1/milestones';
+    const postData = {
+      title: inputTitle,
+      dueDate: inputDate,
+      description: inputDescription,
+    };
+    try {
+      await axios.post(MILE_URL, postData, { withCredentials: true });
+      window.location.href = 'http://localhost:8000/milestones';
+    } catch (err) {
+      window.location.href = 'http://localhost:8000';
+    }
+  };
+
+  const onChangeTitle = (e) => {
+    setTitle(e.target.value);
+  };
+  const onChangeDate = (e) => {
+    setDate(e.target.value);
+  };
+  const onChangeDescription = (e) => {
+    setDescription(e.target.value);
+  };
+  const canSubmit = () => {
+    return !inputTitle;
+  };
+
+  return (
+    <>
+      <h1>New Milestone</h1>
+      <div>create a new milestone to help organize your issues and pull requests.</div>
+      <div>Title</div>
+      <input type="text" placeholder="Title" onChange={onChangeTitle} />
+      <div>Due date (optional)</div>
+      <input type="date" onChange={onChangeDate} />
+      <div>Description (optional)</div>
+      <input type="textarea" onChange={onChangeDescription} />
+      <button type="button" onClick={postMilestone} disabled={canSubmit()}>
+        Create Milestone
+      </button>
+    </>
+  );
+};
+
+export default NewMilestonePage;

--- a/Frontend/Views/Pages/NewMilestonePage.js
+++ b/Frontend/Views/Pages/NewMilestonePage.js
@@ -3,8 +3,8 @@ import axios from 'axios';
 
 const NewMilestonePage = () => {
   const [inputTitle, setTitle] = useState('');
-  const [inputDate, setDate] = useState('');
-  const [inputDescription, setDescription] = useState('');
+  const [inputDate, setDate] = useState(null);
+  const [inputDescription, setDescription] = useState(null);
 
   const postMilestone = async () => {
     const MILE_URL = 'http://localhost:3000/api/v1/milestones';


### PR DESCRIPTION
[comment]: <> (PR 태그를 명시해주세요. [ADD] / [UPDATE] / [BUG])

### 요약
마일스톤 페이지에서, open/close된 마일스톤끼리 볼 수 있는 기능 추가
마일스톤의 open close 상태를 변경 할 수 있음

### 핵심 로직 및 내용

<br>

**1. opened / closed 마일스톤끼리 보여주기**

- 마일스톤 페이지에서, whichMile 이라는 state를 추가. 
- open버튼을 누르면, whichMile = 1  // close버튼을 누르면 whichMile = 0 으로 state 변경
- 마일스톤 렌더링 할 때, `filter().map()`을 이용 (whichMile과 같은 isOpen 값을 가진 마일스톤만 렌더)

<br>
<br>

**2. 마일스톤 open / close 상태 변경**

###### 프론트 부분
- open된 마일스톤은 close 버튼을 가지고있고
- close된 마일스톤은 open 버튼을 가지고 있다.
- 버튼을 누르면 axios.patch 동작. 

###### 백엔드 부분
- 구조분해 할당으로, params 파싱하여 sql문 생성
- 현재 edit 기능만 동작하지만, 백엔드 부분에서 parsing하는 로직은 이미 작성했슴다.



### 기타 참고 사항
백엔드 `req.params` 쓸 때 
`/milestone/:5` 를 파싱하면  `{ milestoneId : ':5' }` 처럼 `:`가 함께 가져와집니당 ㅠ  

