### PR TITLE
[ADD] 필터 라우팅 기능 추가

### DIFF
--- a/Frontend/Views/Components/IssueList.js
+++ b/Frontend/Views/Components/IssueList.js
@@ -1,4 +1,5 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import axios from 'axios';
 import useClickOutside from './Modal';
 
@@ -10,7 +11,7 @@ const getUserId = (cookie) => {
 
 const TopFilter = ({ reloadIssue, setResetQuery }) => {
   const [isVisible, setIsVisible] = useState(false);
-
+  const history = useHistory();
   const domNode = useClickOutside(() => {
     setIsVisible(false);
   });
@@ -20,7 +21,7 @@ const TopFilter = ({ reloadIssue, setResetQuery }) => {
   };
 
   const onClickFilter = (queryString) => {
-    window.history.pushState({}, '', `/issues?${queryString}`);
+    history.push(`/issues?${queryString}`);
     onToggleDropdown();
     setResetQuery(true);
     reloadIssue();
@@ -149,6 +150,8 @@ const ChoiceList = ({ name, values, reloadIssue, onToggleDropdown, setResetQuery
       ItemComponent = null;
   }
 
+  const history = useHistory();
+
   const onSelectAlmaItem = (id) => {
     const oldQueryString = window.location.search;
 
@@ -168,7 +171,8 @@ const ChoiceList = ({ name, values, reloadIssue, onToggleDropdown, setResetQuery
     const newQueryString = Object.keys(newQuery).reduce((acc, key) => {
       return `${acc}${acc === '' ? '' : '&'}${key}=${newQuery[key]}`;
     }, '');
-    window.history.pushState({}, '', `/issues?${newQueryString}`);
+
+    history.push(`/issues?${newQueryString}`);
     onToggleDropdown();
     setResetQuery(true);
     reloadIssue();
@@ -299,6 +303,8 @@ const IssueList = ({ issues, users, labels, milestones, reloadIssue }) => {
   const [isMarkAs, setIsMarkAs] = useState(false);
   const [resetQuery, setResetQuery] = useState(window.location.search !== '');
 
+  const history = useHistory();
+
   useEffect(() => {
     if (checkedIssues.length === 0) {
       setAllChecked(false);
@@ -326,7 +332,7 @@ const IssueList = ({ issues, users, labels, milestones, reloadIssue }) => {
 
   const onClickReset = () => {
     setResetQuery(false);
-    window.history.pushState({}, '', `/issues`);
+    history.push('/issues');
     reloadIssue();
   };
 

--- a/Frontend/Views/Pages/IssuesPage.js
+++ b/Frontend/Views/Pages/IssuesPage.js
@@ -49,6 +49,12 @@ const IssuesPage = () => {
     }
   }, [issueReload]);
 
+  useEffect(() => {
+    const reloadWhenPopstate = () => reloadIssue();
+    window.addEventListener('popstate', reloadWhenPopstate);
+    return () => window.removeEventListener('popstate', reloadWhenPopstate);
+  }, []);
+
   return (
     <div>
       <IssueList

--- a/Frontend/Views/Pages/IssuesPage.js
+++ b/Frontend/Views/Pages/IssuesPage.js
@@ -15,7 +15,7 @@ const IssuesPage = () => {
   const [issueReload, setIssueReload] = useState(true);
 
   const reloadIssue = () => {
-    setIssueReload(!issueReload);
+    setIssueReload((prevIssueReload) => !prevIssueReload);
   };
 
   useEffect(async () => {


### PR DESCRIPTION
[comment]: <> (PR 태그를 명시해주세요. [ADD] / [UPDATE] / [BUG])

### 요약

필터가 변경되고 URI가 변경될 때 라우팅이 가능하게 구현했습니다. 뒤로 가기/앞으로 가기 버튼 클릭 시 이전/이후 필터가 다시 적용됩니다.

### 핵심 로직 및 내용

이슈 리스트 페이지 첫 마운트 시 `popState` 이벤트에 대한 리스너를 등록합니다. 이 리스너는 `popState` 이벤트 발생 시 페이지를 다시 렌더하도록 합니다. 이 리스너는 마운트 해제 시 리액트에 의해 제거됩니다.

### 기타 참고 사항


