### PR TITLE
[ADD] Set Env Variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-# Back ignore
-node_modules/
-.env
 
-# Front ignore
+node_modules/
+*.env
+Env/
 dist/

--- a/Backend/Passport/token.js
+++ b/Backend/Passport/token.js
@@ -14,12 +14,12 @@ exports.tokenCheck = async (req, res, next) => {
     next();
   } catch (err) {
     console.log(err);
-    res.redirect('http://localhost:8000');
+    res.redirect(process.env.NODE_ENV ? process.env.PROD_WEB_URL : process.env.DEV_WEB_URL);
   }
 };
 
 exports.tokenAllocate = (req, res) => {
   const encodedToken = jwt.sign(req.user, process.env.TOKEN_SECRET_KEY);
   res.cookie('jwt', encodedToken);
-  res.redirect('http://localhost:8000/issues');
+  res.redirect(process.env.NODE_ENV ? `${process.env.PROD_WEB_URL}/issues` : `${process.env.DEV_WEB_URL}/issues`);
 };

--- a/Frontend/Views/Components/CommentForm.js
+++ b/Frontend/Views/Components/CommentForm.js
@@ -26,7 +26,7 @@ const CommentForm = ({
   const postComment = async () => {
     try {
       return await axios.post(
-        'http://localhost:3000/api/v1/comments',
+        `${process.env.API_URL}/${process.env.API_VERSION}/comments`,
         {
           description: comment,
           userId: 1,
@@ -43,7 +43,7 @@ const CommentForm = ({
   const patchComment = async () => {
     try {
       return await axios.patch(
-        `http://localhost:3000/api/v1/comments/${commentId}`,
+        `${process.env.API_URL}/${process.env.API_VERSION}/comments/${commentId}`,
         {
           description: comment,
         },
@@ -92,7 +92,7 @@ const CommentForm = ({
       try {
         const result = await axios({
           method: 'post',
-          url: 'http://localhost:3000/api/v1/images',
+          url: `${process.env.API_URL}/${process.env.API_VERSION}/images`,
           data: datas,
           headers: { 'Content-Type': 'multipart/form-data' },
         });

--- a/Frontend/Views/Components/IssueDetailWrapper.js
+++ b/Frontend/Views/Components/IssueDetailWrapper.js
@@ -14,7 +14,9 @@ const IssueDetailWrapper = ({ issueId }) => {
 
   const getIssue = async () => {
     try {
-      return await axios.get(`http://localhost:3000/api/v1/issues/${issueId}`, { withCredentials: true });
+      return await axios.get(`${process.env.API_URL}/${process.env.API_VERSION}/issues/${issueId}`, {
+        withCredentials: true,
+      });
     } catch (err) {
       console.err(err);
     }
@@ -22,7 +24,9 @@ const IssueDetailWrapper = ({ issueId }) => {
 
   const getComments = async () => {
     try {
-      return await axios.get(`http://localhost:3000/api/v1/issues/${issueId}/comments`, { withCredentials: true });
+      return await axios.get(`${process.env.API_URL}/${process.env.API_VERSION}/issues/${issueId}/comments`, {
+        withCredentials: true,
+      });
     } catch (err) {
       console.err(err);
     }

--- a/Frontend/Views/Components/IssueList.js
+++ b/Frontend/Views/Components/IssueList.js
@@ -68,7 +68,7 @@ const MarkAs = ({ checkedIssues, reloadIssue, setIsMarkAs }) => {
     const onChangeStatus = async (status) => {
       try {
         await axios.patch(
-          'http://localhost:3000/api/v1/issues/status',
+          `${process.env.API_URL}/${process.env.API_VERSION}/issues/status`,
           {
             issues: checkedIssues,
             isOpen: status,

--- a/Frontend/Views/Components/LabelForm.js
+++ b/Frontend/Views/Components/LabelForm.js
@@ -51,7 +51,7 @@ const LabelForm = ({ setIsFormVisible, labels, setLabels, isEdit, labelToEdit })
   };
 
   const onClickCreate = async () => {
-    const LABEL_URL = 'http://localhost:3000/api/v1/labels';
+    const LABEL_URL = `${process.env.API_URL}/${process.env.API_VERSION}/labels`;
     const postData = {
       name,
       description,
@@ -67,7 +67,7 @@ const LabelForm = ({ setIsFormVisible, labels, setLabels, isEdit, labelToEdit })
   };
 
   const onClickEdit = async () => {
-    const LABEL_URL = 'http://localhost:3000/api/v1/labels';
+    const LABEL_URL = `${process.env.API_URL}/${process.env.API_VERSION}/labels`;
     const postData = {
       id: labelToEdit.id,
       name,

--- a/Frontend/Views/Components/LabelList.js
+++ b/Frontend/Views/Components/LabelList.js
@@ -4,7 +4,7 @@ import LabelForm from './LabelForm';
 
 const LabelList = ({ labels, setLabels, setIsFormVisible }) => {
   const onClickDelete = async (id) => {
-    const LABEL_URL = 'http://localhost:3000/api/v1/labels';
+    const LABEL_URL = `${process.env.API_URL}/${process.env.API_VERSION}/labels`;
     try {
       await axios.delete(`${LABEL_URL}/${id}`, { withCredentials: true });
       setLabels(labels.filter((label) => label.id !== id));

--- a/Frontend/Views/Components/Milestone.js
+++ b/Frontend/Views/Components/Milestone.js
@@ -5,7 +5,7 @@ import MilestoneEditor from './MilestoneEditor';
 const Milestone = ({ milestone }) => {
   const [isEditButtonClicked, setIsEditButtoneClicked] = useState(false);
 
-  const MILE_URL = `http://localhost:3000/api/v1/milestones/${milestone.id}`;
+  const MILE_URL = `${process.env.API_URL}/${process.env.API_VERSION}/milestones/${milestone.id}`;
 
   const box = {
     border: '1px solid',
@@ -23,9 +23,9 @@ const Milestone = ({ milestone }) => {
     const value = milestone.mileIsOpen ? 0 : 1;
     try {
       await axios.patch(MILE_URL, { isOpen: value }, { withCredentials: true });
-      window.location.href = 'http://localhost:8000/milestones';
+      window.location.href = `${process.env.WEB_URL}/milestones`;
     } catch (err) {
-      window.location.href = 'http://localhost:8000';
+      window.location.href = process.env.WEB_URL;
     }
   };
 
@@ -35,9 +35,9 @@ const Milestone = ({ milestone }) => {
   const onDeleteBtn = async () => {
     try {
       await axios.delete(MILE_URL, { withCredentials: true });
-      window.location.href = 'http://localhost:8000/milestones';
+      window.location.href = `${process.env.WEB_URL}/milestones`;
     } catch (err) {
-      window.location.href = 'http://localhost:8000';
+      window.location.href = process.env.WEB_URL;
     }
   };
 

--- a/Frontend/Views/Components/MilestoneEditor.js
+++ b/Frontend/Views/Components/MilestoneEditor.js
@@ -2,9 +2,9 @@ import React, { useState } from 'react';
 import axios from 'axios';
 
 const MilestoneEditor = ({ milestone, setIsEditButtoneClicked }) => {
-  const [inputTitle, setTitle] = useState(milestone?.title || '');
-  const [inputDate, setDate] = useState(milestone?.dueDate.substring(0, 10) || '');
-  const [inputDescription, setDescription] = useState(milestone?.description || '');
+  const [inputTitle, setTitle] = useState(milestone?.title || null);
+  const [inputDate, setDate] = useState(milestone?.dueDate.substring(0, 10) || null);
+  const [inputDescription, setDescription] = useState(milestone?.description || null);
 
   const onChangeTitle = (e) => {
     setTitle(e.target.value);
@@ -24,8 +24,6 @@ const MilestoneEditor = ({ milestone, setIsEditButtoneClicked }) => {
   };
 
   const onClickSubmit = async () => {
-    const POST_MILE_URL = 'http://localhost:3000/api/v1/milestones';
-    const PATCH_MILE_URL = `http://localhost:3000/api/v1/milestones/${milestone.id}`;
     const config = { withCredentials: true };
     const postData = {
       title: inputTitle,
@@ -33,11 +31,16 @@ const MilestoneEditor = ({ milestone, setIsEditButtoneClicked }) => {
       description: inputDescription,
     };
     try {
-      if (milestone) await axios.patch(PATCH_MILE_URL, postData, config);
-      else await axios.post(POST_MILE_URL, postData, config);
-      window.location.href = 'http://localhost:8000/milestones';
+      if (milestone) {
+        const PATCH_MILE_URL = `${process.env.API_URL}/${process.env.API_VERSION}/milestones/${milestone.id}`;
+        await axios.patch(PATCH_MILE_URL, postData, config);
+      } else {
+        const POST_MILE_URL = `${process.env.API_URL}/${process.env.API_VERSION}/milestones`;
+        await axios.post(POST_MILE_URL, postData, config);
+      }
+      window.location.href = `${process.env.WEB_URL}/milestones`;
     } catch (err) {
-      window.location.href = 'http://localhost:8000';
+      window.location.href = process.env.WEB_URL;
     }
   };
 

--- a/Frontend/Views/Components/NewIssueForm.js
+++ b/Frontend/Views/Components/NewIssueForm.js
@@ -19,7 +19,7 @@ const NewIssueForm = ({ userSelectedData, labelSelectedData, mileSelectedData })
   }, [title, comment]);
 
   const pushIssue = async () => {
-    const ISSUE_URL = 'http://localhost:3000/api/v1/issues';
+    const ISSUE_URL = `${process.env.API_URL}/${process.env.API_VERSION}/issues`;
     const postData = {
       title,
       comment,
@@ -30,9 +30,9 @@ const NewIssueForm = ({ userSelectedData, labelSelectedData, mileSelectedData })
     };
     try {
       await axios.post(ISSUE_URL, postData, { withCredentials: true });
-      window.location.href = 'http://localhost:8000/issues';
+      window.location.href = `${process.env.WEB_URL}/issues`;
     } catch (err) {
-      window.location.href = 'http://localhost:8000';
+      window.location.href = process.env.WEB_URL;
     }
   };
 
@@ -70,7 +70,7 @@ const NewIssueForm = ({ userSelectedData, labelSelectedData, mileSelectedData })
       const datas = new FormData();
       datas.append('image', image, image.name);
       try {
-        const result = await axios.post('http://localhost:3000/api/v1/images', datas, {
+        const result = await axios.post(`${process.env.API_URL}/${process.env.API_VERSION}/images`, datas, {
           'Content-Type': 'multipart/form-data',
           withCredentials: true,
         });

--- a/Frontend/Views/Components/NewIssueOption.js
+++ b/Frontend/Views/Components/NewIssueOption.js
@@ -15,9 +15,9 @@ const NewIssueOption = ({
   const [mileData, setMile] = useState('');
 
   useEffect(async () => {
-    const USER_URL = 'http://localhost:3000/api/v1/users';
-    const LABEL_URL = 'http://localhost:3000/api/v1/labels';
-    const MILE_URL = 'http://localhost:3000/api/v1/milestones';
+    const USER_URL = `${process.env.API_URL}/${process.env.API_VERSION}/users`;
+    const LABEL_URL = `${process.env.API_URL}/${process.env.API_VERSION}/labels`;
+    const MILE_URL = `${process.env.API_URL}/${process.env.API_VERSION}/milestones`;
 
     const userProm = axios.get(USER_URL, { withCredentials: true });
     const labelProm = axios.get(LABEL_URL, { withCredentials: true });
@@ -29,7 +29,7 @@ const NewIssueOption = ({
       setLabel(labelResolve.data);
       setMile(mileResolve.data);
     } catch (err) {
-      window.location.href = 'http://localhost:8000';
+      window.location.href = process.env.WEB_URL;
     }
   }, []);
 

--- a/Frontend/Views/Pages/IssuesPage.js
+++ b/Frontend/Views/Pages/IssuesPage.js
@@ -19,10 +19,10 @@ const IssuesPage = () => {
   };
 
   useEffect(async () => {
-    const ISSUE_URL = 'http://localhost:3000/api/v1/issues';
-    const USER_URL = 'http://localhost:3000/api/v1/users';
-    const LABEL_URL = 'http://localhost:3000/api/v1/labels';
-    const MILE_URL = 'http://localhost:3000/api/v1/milestones';
+    const ISSUE_URL = `${process.env.API_URL}/${process.env.API_VERSION}/issues`;
+    const USER_URL = `${process.env.API_URL}/${process.env.API_VERSION}/users`;
+    const LABEL_URL = `${process.env.API_URL}/${process.env.API_VERSION}/labels`;
+    const MILE_URL = `${process.env.API_URL}/${process.env.API_VERSION}/milestones`;
 
     const queryString = window.location.search;
     const issueProm = axios.get(`${ISSUE_URL}${queryString}`, { withCredentials: true });
@@ -45,7 +45,7 @@ const IssuesPage = () => {
         mileData: toKeyValueMap(milesResolve.data),
       });
     } catch (err) {
-      window.location.href = 'http://localhost:8000';
+      window.location.href = process.env.WEB_URL;
     }
   }, [issueReload]);
 

--- a/Frontend/Views/Pages/LabelPage.js
+++ b/Frontend/Views/Pages/LabelPage.js
@@ -9,7 +9,9 @@ const LabelPage = () => {
   const [isFormVisible, setIsFormVisible] = useState(false);
 
   useEffect(async () => {
-    const { data } = await axios.get('http://localhost:3000/api/v1/labels', { withCredentials: true });
+    const { data } = await axios.get(`${process.env.API_URL}/${process.env.API_VERSION}/labels`, {
+      withCredentials: true,
+    });
     setLabels(data);
   }, []);
 

--- a/Frontend/Views/Pages/MilestonePage.js
+++ b/Frontend/Views/Pages/MilestonePage.js
@@ -8,12 +8,12 @@ const MilestonePage = () => {
   const [whichMile, setWhichMile] = useState(1);
 
   useEffect(async () => {
-    const MILE_URL = 'http://localhost:3000/api/v1/milestones/count';
+    const MILE_URL = `${process.env.API_URL}/${process.env.API_VERSION}/milestones/count`;
     try {
       const milesResolve = await axios.get(MILE_URL, { withCredentials: true });
       setMilestoneList([...Object.values(milesResolve.data)]);
     } catch (err) {
-      window.location.href = 'http://localhost:8000';
+      window.location.href = process.env.WEB_URL;
     }
   }, []);
 

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -1533,18 +1533,18 @@
       }
     },
     "@webpack-cli/info": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.0.2.tgz",
-      "integrity": "sha512-FEfLQwmN4pXZSYSrtp+KC84rFanoCIxXFpS2wUvviDCE2fnajwxw2GXzbj83IlH4Dl8Wq8kJjavVwvxv3YJmnw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.1.0.tgz",
+      "integrity": "sha512-uNWSdaYHc+f3LdIZNwhdhkjjLDDl3jP2+XBqAq9H8DjrJUvlOKdP8TNruy1yEaDfgpAIgbSAN7pye4FEHg9tYQ==",
       "dev": true,
       "requires": {
         "envinfo": "^7.7.3"
       }
     },
     "@webpack-cli/serve": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.0.1.tgz",
-      "integrity": "sha512-WGMaTMTK6NOe29Hw1WBEok9vGLfKg5C6jWzNOS/6HH1YadR+RL+TRWRcSyc81Dzulljhk/Ree9mrDM4Np9GGOQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.1.0.tgz",
+      "integrity": "sha512-7RfnMXCpJ/NThrhq4gYQYILB18xWyoQcBey81oIyVbmgbc6m5ZHHyFK+DyH7pLHJf0p14MxL4mTsoPAgBSTpIg==",
       "dev": true
     },
     "@xtuc/ieee754": {
@@ -2471,14 +2471,14 @@
       "dev": true
     },
     "command-line-usage": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.0.tgz",
-      "integrity": "sha512-Ew1clU4pkUeo6AFVDFxCbnN7GIZfXl48HIOQeFQnkO3oOqvpI7wdqtLRwv9iOCZ/7A+z4csVZeiDdEcj8g6Wiw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz",
+      "integrity": "sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==",
       "dev": true,
       "requires": {
-        "array-back": "^4.0.0",
+        "array-back": "^4.0.1",
         "chalk": "^2.4.2",
-        "table-layout": "^1.0.0",
+        "table-layout": "^1.0.1",
         "typical": "^5.2.0"
       }
     },
@@ -3078,6 +3078,12 @@
         "no-case": "^3.0.3",
         "tslib": "^1.10.0"
       }
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
     },
     "ee-first": {
       "version": "1.1.1",
@@ -3726,9 +3732,9 @@
       }
     },
     "execa": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-      "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
       "dev": true,
       "requires": {
         "cross-spawn": "^7.0.0",
@@ -5162,9 +5168,9 @@
       "dev": true
     },
     "jest-worker": {
-      "version": "26.6.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.1.tgz",
-      "integrity": "sha512-R5IE3qSGz+QynJx8y+ICEkdI2OJ3RJjRQVEyCcFAd3yVhQSEtquziPO29Mlzgn07LOVE8u8jhJ1FqcwegiXWOw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -5278,6 +5284,12 @@
       "requires": {
         "language-subtag-registry": "~0.3.2"
       }
+    },
+    "leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true
     },
     "levn": {
       "version": "0.4.1",
@@ -7821,9 +7833,9 @@
       }
     },
     "tapable": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.0.0.tgz",
-      "integrity": "sha512-bjzn0C0RWoffnNdTzNi7rNDhs1Zlwk2tRXgk8EiHKAOX1Mag3d6T0Y5zNa7l9CJ+EoUne/0UHdwS8tMbkh9zDg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.1.1.tgz",
+      "integrity": "sha512-Wib1S8m2wdpLbmQz0RBEVosIyvb/ykfKXf3ZIDqvWoMg/zTNm6G/tDSuUM61J1kNCDXWJrLHGSFeMhAG+gAGpQ==",
       "dev": true
     },
     "terser": {
@@ -7846,9 +7858,9 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.0.2.tgz",
-      "integrity": "sha512-adg+JLykDi9HkouHqmVg+qbSGyKSJXioNQl7v79xqyaFbv6a/pCd5nVj4HcTDaFNxt6CzDuUrMEnAEbKA/w/QQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.0.3.tgz",
+      "integrity": "sha512-zFdGk8Lh9ZJGPxxPE6jwysOlATWB8GMW8HcfGULWA/nPal+3VdATflQvSBSLQJRCmYZnfFJl6vkRTiwJGNgPiQ==",
       "dev": true,
       "requires": {
         "jest-worker": "^26.6.1",
@@ -8327,9 +8339,9 @@
       }
     },
     "watchpack": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.0.0.tgz",
-      "integrity": "sha512-xSdCxxYZWNk3VK13bZRYhsQpfa8Vg63zXG+3pyU8ouqSLRCv4IGXIp9Kr226q6GBkGRlZrST2wwKtjfKz2m7Cg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.0.1.tgz",
+      "integrity": "sha512-vO8AKGX22ZRo6PiOFM9dC0re8IcKh8Kd/aH2zeqUc6w4/jBGlTy2P7fTC6ekT0NjVeGjgU2dGC5rNstKkeLEQg==",
       "dev": true,
       "requires": {
         "glob-to-regexp": "^0.4.1",
@@ -8346,9 +8358,9 @@
       }
     },
     "webpack": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.3.0.tgz",
-      "integrity": "sha512-0LumZ36pDaWsh+PO3i6FpNQYVqNu5Rs/Jn5AoYQyHpUxIlzn5H7omwApiEzaIUeWDccExOpkNZGO6agCVSqXPg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.4.0.tgz",
+      "integrity": "sha512-udpYTyqz8toTTdaOsL2QKPLeZLt2IEm9qY7yTXuFEQhKu5bk0yQD9BtAdVQksmz4jFbbWOiWmm3NHarO0zr/ng==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",
@@ -8372,29 +8384,29 @@
         "pkg-dir": "^4.2.0",
         "schema-utils": "^3.0.0",
         "tapable": "^2.0.0",
-        "terser-webpack-plugin": "^5.0.0",
+        "terser-webpack-plugin": "^5.0.3",
         "watchpack": "^2.0.0",
-        "webpack-sources": "^2.1.0"
+        "webpack-sources": "^2.1.1"
       }
     },
     "webpack-cli": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.1.0.tgz",
-      "integrity": "sha512-NdhxXMZmoik62Y05t0h1y65LjBM7BwFPq311ihXuMM3RY6dlc4KkCTyHLzTuBEc+bqq6d3xh+CWmU0xRexNJBA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.2.0.tgz",
+      "integrity": "sha512-EIl3k88vaF4fSxWSgtAQR+VwicfLMTZ9amQtqS4o+TDPW9HGaEpbFBbAZ4A3ZOT5SOnMxNOzROsSTPiE8tBJPA==",
       "dev": true,
       "requires": {
-        "@webpack-cli/info": "^1.0.2",
-        "@webpack-cli/serve": "^1.0.1",
-        "ansi-escapes": "^4.3.1",
+        "@webpack-cli/info": "^1.1.0",
+        "@webpack-cli/serve": "^1.1.0",
         "colorette": "^1.2.1",
         "command-line-usage": "^6.1.0",
-        "commander": "^6.0.0",
-        "enquirer": "^2.3.4",
-        "execa": "^4.0.0",
+        "commander": "^6.2.0",
+        "enquirer": "^2.3.6",
+        "execa": "^4.1.0",
         "import-local": "^3.0.2",
-        "interpret": "^2.0.0",
+        "interpret": "^2.2.0",
+        "leven": "^3.1.0",
         "rechoir": "^0.7.0",
-        "v8-compile-cache": "^2.1.0",
+        "v8-compile-cache": "^2.2.0",
         "webpack-merge": "^4.2.2"
       },
       "dependencies": {
@@ -8402,6 +8414,12 @@
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
           "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+          "dev": true
+        },
+        "v8-compile-cache": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+          "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
           "dev": true
         }
       }
@@ -8627,9 +8645,9 @@
       }
     },
     "webpack-sources": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.1.0.tgz",
-      "integrity": "sha512-gOlNIlnBzDC4yIqRcguYXscNRfSL4KSd2EXMXxkTPCao56YW8CbjrY+EfW5fqJNOdWhlFMxGTy1ctwJgeprnXg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.2.0.tgz",
+      "integrity": "sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==",
       "dev": true,
       "requires": {
         "source-list-map": "^2.0.1",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "webpack",
-    "dev": "webpack serve"
+    "build": "webpack --mode production",
+    "dev": "webpack --mode development serve"
   },
   "author": "",
   "license": "ISC",
@@ -19,6 +19,7 @@
     "styled-components": "^5.2.0"
   },
   "devDependencies": {
+    "dotenv": "^8.2.0",
     "@babel/cli": "^7.12.1",
     "@babel/core": "^7.12.3",
     "@babel/polyfill": "^7.12.1",

--- a/Frontend/webpack.config.js
+++ b/Frontend/webpack.config.js
@@ -1,40 +1,51 @@
 const path = require('path');
 const webpack = require('webpack');
+const dotenv = require('dotenv');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
-module.exports = {
-  mode: 'development',
-  entry: ['@babel/polyfill', './Views/index.js'],
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_module/,
-        use: 'babel-loader',
-      },
+module.exports = (env, options) => {
+  const envList = dotenv.config({ path: `./${options.mode || 'development'}.env` }).parsed;
+  console.log(envList);
+
+  return {
+    entry: ['@babel/polyfill', './Views/index.js'],
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_module/,
+          use: 'babel-loader',
+        },
+      ],
+    },
+    resolve: {
+      fallback: { path: require.resolve('path-browserify') },
+    },
+    output: {
+      filename: 'main.js',
+      path: path.join(__dirname, 'dist'),
+    },
+    devServer: {
+      port: 8000,
+      contentBase: path.join(__dirname, 'dist'),
+      host: 'localhost',
+      open: true,
+      historyApiFallback: true,
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: 'Views/index.html',
+        inject: false,
+      }),
+      new webpack.ProvidePlugin({
+        process: 'process/browser',
+      }),
+      new webpack.DefinePlugin({
+        'process.env.API_URL': JSON.stringify(process.env.API_URL),
+        'process.env.API_VERSION': JSON.stringify(process.env.API_VERSION),
+        'process.env.WEB_URL': JSON.stringify(process.env.WEB_URL),
+      }),
+      new webpack.EnvironmentPlugin(['API_URL', 'WEB_URL', 'API_VERSION']),
     ],
-  },
-  resolve: {
-    fallback: { path: require.resolve('path-browserify') },
-  },
-  output: {
-    filename: 'main.js',
-    path: path.join(__dirname, 'dist'),
-  },
-  devServer: {
-    port: 8000,
-    contentBase: path.join(__dirname, 'dist'),
-    host: 'localhost',
-    open: true,
-    historyApiFallback: true,
-  },
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: 'Views/index.html',
-      inject: false,
-    }),
-    new webpack.ProvidePlugin({
-      process: 'process/browser',
-    }),
-  ],
+  };
 };

--- a/Frontend/webpack.config.js
+++ b/Frontend/webpack.config.js
@@ -5,7 +5,6 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = (env, options) => {
   const envList = dotenv.config({ path: `./${options.mode || 'development'}.env` }).parsed;
-  console.log(envList);
 
   return {
     entry: ['@babel/polyfill', './Views/index.js'],
@@ -45,7 +44,6 @@ module.exports = (env, options) => {
         'process.env.API_VERSION': JSON.stringify(process.env.API_VERSION),
         'process.env.WEB_URL': JSON.stringify(process.env.WEB_URL),
       }),
-      new webpack.EnvironmentPlugin(['API_URL', 'WEB_URL', 'API_VERSION']),
     ],
   };
 };


### PR DESCRIPTION
[comment]: <> (PR 태그를 명시해주세요. [ADD] / [UPDATE] / [BUG])

### 요약
dotenv를 webpack에서 사용하기 위해, webpack config 파일 수정
 
### 핵심 로직 및 내용
package.json에 정의한 커스텀 스크립트로 웹팩을 실행한다. 
dev 스크립트는 webpack `--mode development serve`
build 스크립트는 webpack `--mode production` 

npm run 스크립트에 의해서 webpack cli가 동작한다.
webpack cli에 의해, webpack.config.js가 읽힌다. (webpack.config.js는 json형식이어야 한다.) 

webpack.config.js가 기존과 크게 바뀐 부분은, json 객체가 아니라. arrow function이 json 객체를 리턴하는 형태로 바뀐 것이다.  cli에서 입력한 mode나 다른 옵션을 인자로 받을 수 있게 되었다.
webpack.config.js에서 실행되는 함수는 인자로 받은 mode를 기반으로 development.env를 읽을지, productuon.env를 읽을지 결정한다. 

dotenv.config( )로  .env 파일을 읽어온다. 
config함수는 객체를 반환하는데, 이 중 우리가 필요한거는 key 이름이 parsed인 객체다.
parsed에는 key=value 형태로 .env 파일에서 읽어온 것들이 담겨있다.

config가 .env 파싱을 해왔다면, 이제 webpack.config.js에서 process.env.이름 으로 접근 할 수 있다. **그러나 아직은 NODE 런타임 환경변수이기 때문에, NODE환경을 벗어나면 무용지물인 변수다.** 
웹서버가 NODE 런타임 환경변수를 인식할 수 있도록 해주는 것이 webpack.DefinePlugin과 webpack.EnvironmentPlugin이다. 

### webpack.DefinePlugin
이 플러그인은, 웹팩 빌드 시에, 코드에 적힌 환경 변수에 우리가 설정한 값을 대입한다. 
 ```
 new webpack.DefinePlugin({
        'process.env.API_URL': JSON.stringify(process.env.API_URL),
        'process.env.API_VERSION': JSON.stringify(process.env.API_VERSION),
        'process.env.WEB_URL': JSON.stringify(process.env.WEB_URL),
      }),
```
js 코드 상에서 process.env.API_URL 로 적어둔 것을 .env파일 에서 읽어온 값으로 대체해주는 플러그인이다. 
그러나. js 코드에서 console.log(process.env.API_URL)을 하면 undefined가 출력된다.
DefinePlugin은 웹팩이 빌드 할 때, 변수에 실제 값을 할당하는 역할만 수행하기 때문이다.

### webpack.EnvironmentPlugin
노드 런타임(Node runtime)에서 process.env 에 저장되는 환경 변수를 전역 변수로 등록하기 위한 플러그인
솔직히 왜 필요한지 모르겠음 없어도 되는 코드임 .... 
없어도 동작함..
그리고, definePlugin으로 EnviromentPlugin을 모두 대체 가능함..

### 기타 참고 사항
