### PR TITLE
[UPDATE] 이슈 상세 페이지 부가 기능들

### DIFF
--- a/Backend/Routes/commentRoute.js
+++ b/Backend/Routes/commentRoute.js
@@ -2,11 +2,12 @@ const router = require('express').Router();
 const { db } = require('../Models/dbPool');
 
 router.post('/', async (req, res) => {
-  const { userId, issueId, description } = req.body;
+  const { id } = req.user;
+  const { issueId, description } = req.body;
   const conn = await db.getConnection();
   try {
     await conn.beginTransaction();
-    const commentValues = [userId, issueId, description];
+    const commentValues = [id, issueId, description];
     const [result] = await conn.execute(
       'INSERT INTO comments(userId, issueId, description) VALUES(?, ?, ?)',
       commentValues,

--- a/Frontend/Views/Components/IssueDetail/CommentForm.js
+++ b/Frontend/Views/Components/IssueDetail/CommentForm.js
@@ -100,6 +100,7 @@ const CommentForm = ({
     }
     e.preventDefault();
     (isEdit ? editComment : createComment)();
+    setCommentError(false);
   };
 
   const onChangeComment = (e) => {

--- a/Frontend/Views/Components/IssueDetail/CommentList.js
+++ b/Frontend/Views/Components/IssueDetail/CommentList.js
@@ -2,10 +2,21 @@ import React from 'react';
 import CommentWrapper from './CommentWrapper';
 
 const CommentList = ({ commentsData, owner }) => {
+  const getUserId = (cookie) => {
+    const token = cookie.split('=')[1].split('.');
+    const { userId } = JSON.parse(window.atob(token[1].replace('_', '/').replace('-', '+')));
+    return userId;
+  };
+
   return (
     <>
       {commentsData.map((comment) => (
-        <CommentWrapper key={comment.id} comment={comment} isOwner={owner === comment.userId} />
+        <CommentWrapper
+          key={comment.id}
+          comment={comment}
+          isOwner={owner === comment.userId}
+          isWriter={getUserId(document.cookie) === comment.userId}
+        />
       ))}
     </>
   );

--- a/Frontend/Views/Components/IssueDetail/CommentWrapper.js
+++ b/Frontend/Views/Components/IssueDetail/CommentWrapper.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import Comment from './Comment';
 import CommentForm from './CommentForm';
 
-const CommentWrapper = ({ comment, isOwner }) => {
+const CommentWrapper = ({ comment, isOwner, isWriter }) => {
   const [description, setDescription] = useState(comment.description);
   const [isDescription, setIsDescription] = useState(true);
 
@@ -12,9 +12,11 @@ const CommentWrapper = ({ comment, isOwner }) => {
 
   return (
     <>
-      <button type="button" onClick={onClickEdit}>
-        edit
-      </button>
+      {isWriter && (
+        <button type="button" onClick={onClickEdit}>
+          edit
+        </button>
+      )}
       {isDescription ? (
         <Comment description={description} />
       ) : (

--- a/Frontend/Views/Components/IssueDetail/IssueDetailTitle.js
+++ b/Frontend/Views/Components/IssueDetail/IssueDetailTitle.js
@@ -1,10 +1,80 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import ErrorMessage from './ErrorMessage';
 
-const IssueDetailTitle = ({ issueData }) => {
+const IssueDetailTitle = ({ issueData, isOpen }) => {
+  const [title, setTitle] = useState();
+  const [beforeTitle, setBeforeTitle] = useState();
+  const [isEdit, setIsEdit] = useState(false);
+  const [titleError, setTitleError] = useState(false);
+  const [editDisabled, setDisabled] = useState(false);
+
+  useEffect(() => {
+    if (issueData) setTitle(issueData.title);
+  }, [issueData]);
+
+  useEffect(() => {
+    setDisabled(!title);
+  }, [title]);
+
+  const patchTitle = async () => {
+    const ISSUE_URL = `http://localhost:3000/api/v1/issues/${issueData.id}/title`;
+    try {
+      return await axios.patch(ISSUE_URL, { title }, { withCredentials: true });
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  const editTitle = async () => {
+    await patchTitle();
+  };
+
+  const onChangeTitle = (e) => {
+    setTitle(e.target.value);
+  };
+
+  const onClickEdit = () => {
+    if (isEdit) {
+      let isTitle = false;
+
+      if (title.trim() === '') {
+        setTitleError(true);
+        isTitle = true;
+      }
+      if (isTitle) return;
+
+      editTitle();
+    }
+    if (!isEdit) setBeforeTitle(title);
+    setIsEdit(!isEdit);
+  };
+
+  const onClickCancel = () => {
+    setTitle(beforeTitle);
+    setIsEdit(false);
+  };
+
   return (
     <>
-      <div>{issueData.title}</div>
-      <div>{`#${issueData.id}`}</div>
+      {isEdit ? (
+        <input type="text" placeholder="Title" onChange={onChangeTitle} value={title} />
+      ) : (
+        <div>
+          {title}
+          {`#${issueData.id}`}
+        </div>
+      )}
+      {titleError && <ErrorMessage message="제목을 입력해주세요." />}
+      <button type="button" onClick={onClickEdit} disabled={editDisabled}>
+        {isEdit ? 'save' : 'edit'}
+      </button>
+      {isEdit && (
+        <button type="button" onClick={onClickCancel}>
+          cancel
+        </button>
+      )}
+      <div>{isOpen ? 'Open' : 'Close'}</div>
     </>
   );
 };

--- a/Frontend/Views/Components/IssueDetail/IssueDetailTitle.js
+++ b/Frontend/Views/Components/IssueDetail/IssueDetailTitle.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
-import ErrorMessage from './ErrorMessage';
+import ErrorMessage from '../ErrorMessage';
 
 const IssueDetailTitle = ({ issueData, isOpen }) => {
   const [title, setTitle] = useState();
@@ -45,6 +45,7 @@ const IssueDetailTitle = ({ issueData, isOpen }) => {
       if (isTitle) return;
 
       editTitle();
+      setTitleError(false);
     }
     if (!isEdit) setBeforeTitle(title);
     setIsEdit(!isEdit);

--- a/Frontend/Views/Components/IssueDetail/IssueDetailWrapper.js
+++ b/Frontend/Views/Components/IssueDetail/IssueDetailWrapper.js
@@ -10,6 +10,7 @@ const IssueDetailWrapper = ({ issueId }) => {
   const [labelSelectedData, setLabelSelectedData] = useState([]);
   const [mileSelectedData, setMileSelectedData] = useState([]);
   const [issueData, setIssueData] = useState({});
+  const [isOpen, setIsOpen] = useState();
   const [commentsData, setCommentsData] = useState([]);
 
   const getIssue = async () => {
@@ -38,6 +39,7 @@ const IssueDetailWrapper = ({ issueId }) => {
     setLabelSelectedData([...result.data.labels]);
     setMileSelectedData([result.data.issue.milestoneId]);
     setIssueData(result.data.issue);
+    setIsOpen(result.data.issue.isOpen);
   };
 
   const readComments = async () => {
@@ -56,7 +58,7 @@ const IssueDetailWrapper = ({ issueId }) => {
 
   return (
     <>
-      <IssueDetailTitle issueData={issueData} />
+      <IssueDetailTitle issueData={issueData} isOpen={isOpen} />
       <CommentList commentsData={commentsData} owner={issueData.userId} />
       <NewIssueOption
         userSelectedData={userSelectedData}
@@ -66,7 +68,13 @@ const IssueDetailWrapper = ({ issueId }) => {
         setLabelSelectedData={setLabelSelectedData}
         setMileSelectedData={setMileSelectedData}
       />
-      <CommentForm issueId={issueId} commentsData={commentsData} setCommentsData={setCommentsData} />
+      <CommentForm
+        issueId={issueId}
+        commentsData={commentsData}
+        setCommentsData={setCommentsData}
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+      />
     </>
   );
 };


### PR DESCRIPTION
[comment]: <> (PR 태그를 명시해주세요. [ADD] / [UPDATE] / [BUG])

### 요약

이슈 상세 페이지를 완성하기 위해 기능들을 추가했습니다. 

### 핵심 로직 및 내용

**Frontend**

- 이슈를 `close`, `reopen` 할 수 있도록 했습니다. 
- 코멘트의 변경을 작성자만 가능하도록 했습니다. 
- 이슈의 제목을 변경할 수 있도록 했습니다. 
- `ErrorMessage`가 제목과 코멘트 정상 추가시 삭제되도록 했습니다. 

**Backend**

- 코멘트 추가시 유저 정보를 JWT를 통해 확인하도록 변경했습니다. 

### 기타 참고 사항

- `CommentForm`의 147번째 줄에 이중 삼항연산자가 있습니다. 좋은 해결법 아시는 분 있으실까요...?
- JWT decoding시 참고했던 자료입니다. 
  - [JWT uses base64url encoding, not base64 encoding](https://github.com/simonh1000/elm-jwt/issues/1)
