### PR TITLE
[UPDATE] 이슈 상세 페이지 이동, 상세 페이지 버그 수정, 함수 추가, 헤더 추가 

### DIFF
--- a/Frontend/Sources/user.js
+++ b/Frontend/Sources/user.js
@@ -1,7 +1,11 @@
-const getUserId = (cookie) => {
+export const getUserId = (cookie) => {
   const token = cookie.split('=')[1].split('.');
   const { userId } = JSON.parse(window.atob(token[1].replace('_', '/').replace('-', '+')));
   return userId;
 };
 
-export default getUserId;
+export const getUserImageLink = (cookie) => {
+  const token = cookie.split('=')[1].split('.');
+  const { imageLink } = JSON.parse(window.atob(token[1].replace('_', '/').replace('-', '+')));
+  return imageLink;
+};

--- a/Frontend/Views/App.js
+++ b/Frontend/Views/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { useHistory, Route, Switch } from 'react-router-dom';
 
 import NewIssuePage from './Pages/NewIssuePage';
 import IssueMainPage from './Pages/IssueMainPage';
@@ -10,8 +10,15 @@ import MilestonPage from './Pages/MilestonePage';
 import NewMilestonePage from './Pages/NewMilestonePage';
 
 const App = () => {
+  const history = useHistory();
+
+  const onClickHeader = () => {
+    history.push('/issues');
+  };
+
   return (
-    <Router>
+    <>
+      <div onClick={onClickHeader}>Issues</div>
       <Route exact path="/" component={LoginPage} />
       <Route exact path="/issues" component={IssueMainPage} />
       <Switch>
@@ -23,7 +30,7 @@ const App = () => {
         <Route exact path="/milestones/new" component={NewMilestonePage} />
       </Switch>
       <Route exact path="/labels" component={LabelPage} />
-    </Router>
+    </>
   );
 };
 

--- a/Frontend/Views/Components/IssueDetail/IssueDetailWrapper.js
+++ b/Frontend/Views/Components/IssueDetail/IssueDetailWrapper.js
@@ -36,9 +36,7 @@ const IssueDetailWrapper = ({ issueId }) => {
     const result = await getIssue();
     setUserSelectedData([...result.data.assignees]);
     setLabelSelectedData([...result.data.labels]);
-    if (result.data.issue.milestoneId === null) {
-      setMileSelectedData([]);
-    } else {
+    if (result.data.issue.milestoneId !== null) {
       setMileSelectedData([result.data.issue.milestoneId]);
     }
     setIssueData(result.data.issue);

--- a/Frontend/Views/Components/IssueDetail/IssueDetailWrapper.js
+++ b/Frontend/Views/Components/IssueDetail/IssueDetailWrapper.js
@@ -18,7 +18,7 @@ const IssueDetailWrapper = ({ issueId }) => {
         withCredentials: true,
       });
     } catch (err) {
-      console.err(err);
+      console.err(err.message);
     }
   };
 
@@ -28,7 +28,7 @@ const IssueDetailWrapper = ({ issueId }) => {
         withCredentials: true,
       });
     } catch (err) {
-      console.err(err);
+      console.err(err.message);
     }
   };
 
@@ -36,7 +36,11 @@ const IssueDetailWrapper = ({ issueId }) => {
     const result = await getIssue();
     setUserSelectedData([...result.data.assignees]);
     setLabelSelectedData([...result.data.labels]);
-    setMileSelectedData([result.data.issue.milestoneId]);
+    if (result.data.issue.milestoneId === null) {
+      setMileSelectedData([]);
+    } else {
+      setMileSelectedData([result.data.issue.milestoneId]);
+    }
     setIssueData(result.data.issue);
   };
 
@@ -50,7 +54,7 @@ const IssueDetailWrapper = ({ issueId }) => {
       await readIssue();
       await readComments();
     } catch (err) {
-      console.err(err);
+      console.log(err);
     }
   }, []);
 

--- a/Frontend/Views/Components/IssueList/IssueListItem.js
+++ b/Frontend/Views/Components/IssueList/IssueListItem.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 
 const IssueListItem = ({
   issue,
@@ -14,6 +15,8 @@ const IssueListItem = ({
   isMarkAs,
 }) => {
   const [isChecked, setIsChecked] = useState(false);
+
+  const history = useHistory();
 
   useEffect(() => {
     setIsChecked(isCheckAll);
@@ -42,12 +45,16 @@ const IssueListItem = ({
     }
   };
 
+  const onClickTitle = (id) => {
+    history.push(`/issues/${id}`);
+  };
+
   return (
     <div>
       <br />
       <div>
         <input key={issue.id} checked={isChecked} type="checkbox" onChange={onCheckIssue} />
-        <span>{issue.title}</span>
+        <span onClick={() => onClickTitle(issue.id)}>{issue.title}</span>
         <span>
           {labels.map((label) => (
             <span key={label.id}>{` ${label.name}`}</span>

--- a/Frontend/Views/Components/NewIssue/NewIssueForm.js
+++ b/Frontend/Views/Components/NewIssue/NewIssueForm.js
@@ -25,7 +25,6 @@ const NewIssueForm = ({ userSelectedData, labelSelectedData, mileSelectedData })
     const postData = {
       title,
       comment,
-      userId: getUserId(document.cookie),
       milestoneId: mileSelectedData.map((elem) => elem.id)[0],
       labels: labelSelectedData.map((elem) => elem.id),
       assignees: userSelectedData.map((elem) => elem.id),

--- a/Frontend/Views/Components/NewIssue/NewIssueForm.js
+++ b/Frontend/Views/Components/NewIssue/NewIssueForm.js
@@ -3,7 +3,8 @@ import { useHistory } from 'react-router-dom';
 import axios from 'axios';
 import MarkdownRender from '../MarkdownRender';
 import ErrorMessage from '../ErrorMessage';
-import getUserId from '../../../Sources/user';
+import { getUserId, getUserImageLink } from '../../../Sources/user';
+import UserPhotoBlock from '../UserPhotoBlock';
 
 const NewIssueForm = ({ userSelectedData, labelSelectedData, mileSelectedData }) => {
   const history = useHistory();
@@ -25,7 +26,6 @@ const NewIssueForm = ({ userSelectedData, labelSelectedData, mileSelectedData })
       title,
       comment,
       userId: getUserId(document.cookie),
-      // userId: 1,
       milestoneId: mileSelectedData.map((elem) => elem.id)[0],
       labels: labelSelectedData.map((elem) => elem.id),
       assignees: userSelectedData.map((elem) => elem.id),
@@ -90,6 +90,7 @@ const NewIssueForm = ({ userSelectedData, labelSelectedData, mileSelectedData })
 
   return (
     <>
+      <UserPhotoBlock imageLink={getUserImageLink(document.cookie)} />
       <input type="text" placeholder="Title" onChange={onChangeTitle} />
       {titleError && <ErrorMessage message="제목을 입력해주세요." />}
       <textarea type="text" placeholder="Leave a comment" onChange={onChangeComment} value={comment} />

--- a/Frontend/Views/Components/UserPhotoBlock.js
+++ b/Frontend/Views/Components/UserPhotoBlock.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const UserPhotoBlock = ({ imageLink }) => {
+  return <img src={imageLink} alt="user" />;
+};
+
+export default UserPhotoBlock;

--- a/Frontend/Views/index.js
+++ b/Frontend/Views/index.js
@@ -1,7 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 import App from './App';
 
 const root = document.querySelector('#root');
 
-ReactDOM.render(<App />, root);
+ReactDOM.render(
+  <Router>
+    <App />
+  </Router>,
+  root,
+);


### PR DESCRIPTION
[comment]: <> (PR 태그를 명시해주세요. [ADD] / [UPDATE] / [BUG])

### 요약

- 이슈 상세 페이지 이동
- userPhotoBlock 컴포넌트
- getUserImageLink
- header 추가
- milestone null 체크

### 핵심 로직 및 내용
- 이슈 제목을 클릭하면 이슈 상세 페이지로 넘어갑니다.
- 이슈 상세 페이지로 넘어갈 때, 해당 이슈에 마일스톤이 지정되지 않은 경우 생기던 오류를 수정하였습니다. (null이면 빈 배열로 교체)
- header를 모든 페이지에 추가하기 위해 App.js에서 선언되던 Router를 index.js로 이동하였습니다. (Router로 감싸진 컴포넌트에서는 Link나 history를 사용할 수 없기 때문)
- userPhotoBlock - 유저 사진 출력 컴포넌트
- getUserImageLink - 접속한 유저의 이미지를 cookie에서 추출하여 반환합니다

### 기타 참고 사항
