### PR TITLE
[ADD] CONTEXT-REDUCER 적용

### DIFF
--- a/Backend/Routes/milestoneRoute.js
+++ b/Backend/Routes/milestoneRoute.js
@@ -79,10 +79,10 @@ router.post('/', async (req, res) => {
   res.json({});
 });
 
-router.delete('/', async (req, res) => {
+router.delete('/:milestoneId', async (req, res) => {
   const query = `DELETE FROM milestones WHERE id=? `;
   const { milestoneId } = req.params;
-  await db.execute(query, milestoneId);
+  await db.execute(query, [milestoneId]);
   res.json({});
 });
 

--- a/Frontend/.prettierrc
+++ b/Frontend/.prettierrc
@@ -3,6 +3,6 @@
   "semi": true,
   "tabWidth": 2,
   "trailingComma": "all",
-  "printWidth": 120,
+  "printWidth": 150,
   "bracketSpacing": true
 }

--- a/Frontend/Views/App.js
+++ b/Frontend/Views/App.js
@@ -21,22 +21,24 @@ const App = () => {
   const [users, usersDispatch] = useReducer(usersReducer, '');
 
   useEffect(async () => {
-    const USER_URL = `${process.env.API_URL}/${process.env.API_VERSION}/users`;
-    const LABEL_URL = `${process.env.API_URL}/${process.env.API_VERSION}/labels`;
-    const MILE_URL = `${process.env.API_URL}/${process.env.API_VERSION}/milestones`;
+    if (window.location.href !== process.env.WEB_URL + '/') {
+      const USER_URL = `${process.env.API_URL}/${process.env.API_VERSION}/users`;
+      const LABEL_URL = `${process.env.API_URL}/${process.env.API_VERSION}/labels`;
+      const MILE_URL = `${process.env.API_URL}/${process.env.API_VERSION}/milestones`;
 
-    const userProm = axios.get(USER_URL, { withCredentials: true });
-    const labelProm = axios.get(LABEL_URL, { withCredentials: true });
-    const mileProm = axios.get(MILE_URL, { withCredentials: true });
+      const userProm = axios.get(USER_URL, { withCredentials: true });
+      const labelProm = axios.get(LABEL_URL, { withCredentials: true });
+      const mileProm = axios.get(MILE_URL, { withCredentials: true });
 
-    try {
-      const [userResolve, labelResolve, mileResolve] = await Promise.all([userProm, labelProm, mileProm]);
+      try {
+        const [userResolve, labelResolve, mileResolve] = await Promise.all([userProm, labelProm, mileProm]);
 
-      milestonesDispatch({ type: 'setInitial', data: mileResolve.data });
-      labelsDispatch({ type: 'setInitial', data: labelResolve.data });
-      usersDispatch({ type: 'setInitial', data: userResolve.data });
-    } catch (err) {
-      window.location.href = process.env.WEB_URL;
+        milestonesDispatch({ type: 'setInitial', data: mileResolve.data });
+        labelsDispatch({ type: 'setInitial', data: labelResolve.data });
+        usersDispatch({ type: 'setInitial', data: userResolve.data });
+      } catch (err) {
+        window.location.href = process.env.WEB_URL;
+      }
     }
   }, []);
 

--- a/Frontend/Views/App.js
+++ b/Frontend/Views/App.js
@@ -8,34 +8,7 @@ import LoginPage from './Pages/LoginPage';
 import LabelPage from './Pages/LabelPage';
 import MilestonPage from './Pages/MilestonePage';
 import NewMilestonePage from './Pages/NewMilestonePage';
-
-const milestonesReducer = (milestones, { type, data }) => {
-  switch (type) {
-    case 'setInitial':
-      return data;
-    default:
-  }
-};
-
-const labelsReducer = (labels, { type, data }) => {
-  switch (type) {
-    case 'setInitial':
-      return data;
-    default:
-  }
-};
-
-const usersReducer = (users, { type, data }) => {
-  switch (type) {
-    case 'setInitial':
-      return data;
-    default:
-  }
-};
-
-export const UsersContext = React.createContext();
-export const MilestonesContext = React.createContext();
-export const LabelsContext = React.createContext();
+import { milestonesReducer, labelsReducer, usersReducer, MilestonesContext, LabelsContext, UsersContext } from './store/AppStore';
 
 const App = () => {
   const history = useHistory();
@@ -88,5 +61,4 @@ const App = () => {
     </LabelsContext.Provider>
   );
 };
-
 export default App;

--- a/Frontend/Views/App.js
+++ b/Frontend/Views/App.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useReducer } from 'react';
 import axios from 'axios';
 import { useHistory, Route, Switch } from 'react-router-dom';
-
 import NewIssuePage from './Pages/NewIssuePage';
 import IssueMainPage from './Pages/IssueMainPage';
 import IssueDetailPage from './Pages/IssueDetailPage';

--- a/Frontend/Views/App.js
+++ b/Frontend/Views/App.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useReducer } from 'react';
+import axios from 'axios';
 import { useHistory, Route, Switch } from 'react-router-dom';
 
 import NewIssuePage from './Pages/NewIssuePage';
@@ -9,28 +10,83 @@ import LabelPage from './Pages/LabelPage';
 import MilestonPage from './Pages/MilestonePage';
 import NewMilestonePage from './Pages/NewMilestonePage';
 
+const milestonesReducer = (milestones, { type, data }) => {
+  switch (type) {
+    case 'setInitial':
+      return data;
+    default:
+  }
+};
+
+const labelsReducer = (labels, { type, data }) => {
+  switch (type) {
+    case 'setInitial':
+      return data;
+    default:
+  }
+};
+
+const usersReducer = (users, { type, data }) => {
+  switch (type) {
+    case 'setInitial':
+      return data;
+    default:
+  }
+};
+
+export const UsersContext = React.createContext();
+export const MilestonesContext = React.createContext();
+export const LabelsContext = React.createContext();
+
 const App = () => {
   const history = useHistory();
 
   const onClickHeader = () => {
     history.push('/issues');
   };
+  const [milestones, milestonesDispatch] = useReducer(milestonesReducer, '');
+  const [labels, labelsDispatch] = useReducer(labelsReducer, '');
+  const [users, usersDispatch] = useReducer(usersReducer, '');
+
+  useEffect(async () => {
+    const USER_URL = `${process.env.API_URL}/${process.env.API_VERSION}/users`;
+    const LABEL_URL = `${process.env.API_URL}/${process.env.API_VERSION}/labels`;
+    const MILE_URL = `${process.env.API_URL}/${process.env.API_VERSION}/milestones`;
+
+    const userProm = axios.get(USER_URL, { withCredentials: true });
+    const labelProm = axios.get(LABEL_URL, { withCredentials: true });
+    const mileProm = axios.get(MILE_URL, { withCredentials: true });
+
+    try {
+      const [userResolve, labelResolve, mileResolve] = await Promise.all([userProm, labelProm, mileProm]);
+
+      milestonesDispatch({ type: 'setInitial', data: mileResolve.data });
+      labelsDispatch({ type: 'setInitial', data: labelResolve.data });
+      usersDispatch({ type: 'setInitial', data: userResolve.data });
+    } catch (err) {
+      window.location.href = process.env.WEB_URL;
+    }
+  }, []);
 
   return (
-    <>
-      <div onClick={onClickHeader}>Issues</div>
-      <Route exact path="/" component={LoginPage} />
-      <Route exact path="/issues" component={IssueMainPage} />
-      <Switch>
-        <Route exact path="/issues/new" component={NewIssuePage} />
-        <Route exact path="/issues/:issueId" component={IssueDetailPage} />
-      </Switch>
-      <Switch>
-        <Route exact path="/milestones" component={MilestonPage} />
-        <Route exact path="/milestones/new" component={NewMilestonePage} />
-      </Switch>
-      <Route exact path="/labels" component={LabelPage} />
-    </>
+    <LabelsContext.Provider value={{ labels, labelsDispatch }}>
+      <UsersContext.Provider value={{ users, usersDispatch }}>
+        <MilestonesContext.Provider value={{ milestones, milestonesDispatch }}>
+          <div onClick={onClickHeader}>Issues</div>
+          <Route exact path="/" component={LoginPage} />
+          <Route exact path="/issues" component={IssueMainPage} />
+          <Switch>
+            <Route exact path="/issues/new" component={NewIssuePage} />
+            <Route exact path="/issues/:issueId" component={IssueDetailPage} />
+          </Switch>
+          <Switch>
+            <Route exact path="/milestones" component={MilestonPage} />
+            <Route exact path="/milestones/new" component={NewMilestonePage} />
+          </Switch>
+          <Route exact path="/labels" component={LabelPage} />
+        </MilestonesContext.Provider>
+      </UsersContext.Provider>
+    </LabelsContext.Provider>
   );
 };
 

--- a/Frontend/Views/Components/IssueList/Alma.js
+++ b/Frontend/Views/Components/IssueList/Alma.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import Dropdown from './Dropdown';
 
-const Alma = ({ users, labels, milestones, setResetQuery }) => {
+const Alma = ({ users, labels, milestones }) => {
   return (
     <>
-      <Dropdown name="author" values={users} setResetQuery={setResetQuery} />
-      <Dropdown name="label" values={labels} setResetQuery={setResetQuery} />
-      <Dropdown name="milestone" values={milestones} setResetQuery={setResetQuery} />
-      <Dropdown name="assignee" values={users} setResetQuery={setResetQuery} />
+      <Dropdown name="author" values={users} />
+      <Dropdown name="label" values={labels} />
+      <Dropdown name="milestone" values={milestones} />
+      <Dropdown name="assignee" values={users} />
     </>
   );
 };

--- a/Frontend/Views/Components/IssueList/Alma.js
+++ b/Frontend/Views/Components/IssueList/Alma.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import Dropdown from './Dropdown';
 
-const Alma = ({ users, labels, milestones, reloadIssue, setResetQuery }) => {
+const Alma = ({ users, labels, milestones, setResetQuery }) => {
   return (
     <>
-      <Dropdown name="author" values={users} reloadIssue={reloadIssue} setResetQuery={setResetQuery} />
-      <Dropdown name="label" values={labels} reloadIssue={reloadIssue} setResetQuery={setResetQuery} />
-      <Dropdown name="milestone" values={milestones} reloadIssue={reloadIssue} setResetQuery={setResetQuery} />
-      <Dropdown name="assignee" values={users} reloadIssue={reloadIssue} setResetQuery={setResetQuery} />
+      <Dropdown name="author" values={users} setResetQuery={setResetQuery} />
+      <Dropdown name="label" values={labels} setResetQuery={setResetQuery} />
+      <Dropdown name="milestone" values={milestones} setResetQuery={setResetQuery} />
+      <Dropdown name="assignee" values={users} setResetQuery={setResetQuery} />
     </>
   );
 };

--- a/Frontend/Views/Components/IssueList/ChoiceList.js
+++ b/Frontend/Views/Components/IssueList/ChoiceList.js
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 import { ReloadContext } from '../../Pages/IssuesPage';
+import { IsQueryContext, isQueryContext } from './IssueList';
 const UserItem = ({ value }) => {
   return (
     <>
@@ -28,8 +29,9 @@ const MilestoneItem = ({ value }) => {
   );
 };
 
-const ChoiceList = ({ name, values, onToggleDropdown, setResetQuery }) => {
+const ChoiceList = ({ name, values, onToggleDropdown }) => {
   const { reloadDispatch } = useContext(ReloadContext);
+  const { isQueryDispatch } = useContext(IsQueryContext);
   let ItemComponent;
   switch (name) {
     case 'author':
@@ -77,7 +79,7 @@ const ChoiceList = ({ name, values, onToggleDropdown, setResetQuery }) => {
 
     history.push(`/issues?${newQueryString}`);
     onToggleDropdown();
-    setResetQuery(true);
+    isQueryDispatch({ type: 'switch', data: true });
     reloadDispatch({ type: 'switch' });
   };
 

--- a/Frontend/Views/Components/IssueList/ChoiceList.js
+++ b/Frontend/Views/Components/IssueList/ChoiceList.js
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { useHistory } from 'react-router-dom';
-
+import { ReloadContext } from '../../Pages/IssuesPage';
 const UserItem = ({ value }) => {
   return (
     <>
@@ -28,7 +28,8 @@ const MilestoneItem = ({ value }) => {
   );
 };
 
-const ChoiceList = ({ name, values, reloadIssue, onToggleDropdown, setResetQuery }) => {
+const ChoiceList = ({ name, values, onToggleDropdown, setResetQuery }) => {
+  const { reloadDispatch } = useContext(ReloadContext);
   let ItemComponent;
   switch (name) {
     case 'author':
@@ -77,7 +78,7 @@ const ChoiceList = ({ name, values, reloadIssue, onToggleDropdown, setResetQuery
     history.push(`/issues?${newQueryString}`);
     onToggleDropdown();
     setResetQuery(true);
-    reloadIssue();
+    reloadDispatch({ type: 'switch' });
   };
 
   return (

--- a/Frontend/Views/Components/IssueList/ChoiceList.js
+++ b/Frontend/Views/Components/IssueList/ChoiceList.js
@@ -1,7 +1,8 @@
 import React, { useContext } from 'react';
 import { useHistory } from 'react-router-dom';
-import { ReloadContext } from '../../Pages/IssuesPage';
-import { IsQueryContext, isQueryContext } from './IssueList';
+import { ReloadContext } from '../../store/IssuesPageStore';
+import { IsQueryContext } from '../../store/IssuesListStore';
+
 const UserItem = ({ value }) => {
   return (
     <>

--- a/Frontend/Views/Components/IssueList/Dropdown.js
+++ b/Frontend/Views/Components/IssueList/Dropdown.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import useClickOutside from '../Modal';
 import ChoiceList from './ChoiceList';
 
-const Dropdown = ({ name, values, reloadIssue, setResetQuery }) => {
+const Dropdown = ({ name, values, setResetQuery }) => {
   const [isVisible, setIsVisible] = useState(false);
 
   const domNode = useClickOutside(() => {
@@ -20,13 +20,7 @@ const Dropdown = ({ name, values, reloadIssue, setResetQuery }) => {
           {name}
         </button>
         {isVisible && (
-          <ChoiceList
-            name={name}
-            values={values}
-            reloadIssue={reloadIssue}
-            onToggleDropdown={onToggleDropdown}
-            setResetQuery={setResetQuery}
-          />
+          <ChoiceList name={name} values={values} onToggleDropdown={onToggleDropdown} setResetQuery={setResetQuery} />
         )}
       </div>
     </>

--- a/Frontend/Views/Components/IssueList/Dropdown.js
+++ b/Frontend/Views/Components/IssueList/Dropdown.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import useClickOutside from '../Modal';
 import ChoiceList from './ChoiceList';
 
-const Dropdown = ({ name, values, setResetQuery }) => {
+const Dropdown = ({ name, values }) => {
   const [isVisible, setIsVisible] = useState(false);
 
   const domNode = useClickOutside(() => {
@@ -19,9 +19,7 @@ const Dropdown = ({ name, values, setResetQuery }) => {
         <button type="button" onClick={onToggleDropdown}>
           {name}
         </button>
-        {isVisible && (
-          <ChoiceList name={name} values={values} onToggleDropdown={onToggleDropdown} setResetQuery={setResetQuery} />
-        )}
+        {isVisible && <ChoiceList name={name} values={values} onToggleDropdown={onToggleDropdown} />}
       </div>
     </>
   );

--- a/Frontend/Views/Components/IssueList/IssueList.js
+++ b/Frontend/Views/Components/IssueList/IssueList.js
@@ -121,8 +121,8 @@ const IssueList = () => {
     return {
       issue,
       author: mappedUsers[issue.userId],
-      labels: issue.labels || issue.labels.map((id) => mappedLabels[id]),
-      assignees: issue.assignees || issue.assignees.map((id) => mappedUsers[id]),
+      labels: issue.labels.map((id) => mappedLabels[id]),
+      assignees: issue.assignees.map((id) => mappedUsers[id]),
       milestone: mappedMilestones[issue.milestoneId],
     };
   };
@@ -151,6 +151,7 @@ const IssueList = () => {
           </IsCheckAllContext.Provider>
         </AllCheckedContext.Provider>
       </IsMarkAsContext.Provider>
+      {console.log(checkedIssues)}
     </div>
   );
 };

--- a/Frontend/Views/Components/IssueList/IssueList.js
+++ b/Frontend/Views/Components/IssueList/IssueList.js
@@ -1,72 +1,23 @@
-import React, { useContext, useEffect, useReducer, useState } from 'react';
+import React, { useContext, useEffect, useReducer } from 'react';
 import { useHistory } from 'react-router-dom';
 import IssueListItem from './IssueListItem';
 import TopFilter from './TopFilter';
 import MarkAs from './MarkAs';
 import Alma from './Alma';
-import { MilestonesContext, LabelsContext, UsersContext } from '../../App';
-import { IssuesContext, ReloadContext } from '../../Pages/IssuesPage';
-
-const toKeyValueMap = (records) => {
-  if (!records) return;
-  const map = {};
-  records.forEach((record) => {
-    map[record.id] = record;
-  });
-  return map;
-};
-
-const isQueryReducer = (isQuery, { type, data }) => {
-  switch (type) {
-    case 'switch':
-      return data;
-    default:
-  }
-};
-
-const checkedIssuesReducer = (checkedIssues, { type, data, option }) => {
-  switch (type) {
-    case 'addAll':
-      return data;
-    case 'deleteAll':
-      return [];
-    case 'add':
-      return [...checkedIssues, data];
-    case 'filter':
-      return checkedIssues.filter((elem) => elem !== option);
-    default:
-  }
-};
-
-const isCheckAllReducer = (isCheckAll, { type, data }) => {
-  switch (type) {
-    case 'set':
-      return data;
-    default:
-  }
-};
-
-const allCheckedReducer = (allChecked, { type, data }) => {
-  switch (type) {
-    case 'set':
-      return data;
-    default:
-  }
-};
-
-const isMarkAsReducer = (isMarkAs, { type, data }) => {
-  switch (type) {
-    case 'set':
-      return data;
-    default:
-  }
-};
-
-export const IsQueryContext = React.createContext();
-export const CheckedIssuesContext = React.createContext();
-export const IsCheckAllContext = React.createContext();
-export const AllCheckedContext = React.createContext();
-export const IsMarkAsContext = React.createContext();
+import { MilestonesContext, LabelsContext, UsersContext } from '../../store/AppStore';
+import { IssuesContext, ReloadContext } from '../../store/IssuesPageStore';
+import {
+  isQueryReducer,
+  checkedIssuesReducer,
+  isCheckAllReducer,
+  allCheckedReducer,
+  isMarkAsReducer,
+  IsQueryContext,
+  CheckedIssuesContext,
+  IsCheckAllContext,
+  AllCheckedContext,
+  IsMarkAsContext,
+} from '../../store/IssuesListStore';
 
 const IssueList = () => {
   const { reloadDispatch } = useContext(ReloadContext);
@@ -74,9 +25,6 @@ const IssueList = () => {
   const { users } = useContext(UsersContext);
   const { labels } = useContext(LabelsContext);
   const { milestones } = useContext(MilestonesContext);
-  const mappedUsers = toKeyValueMap(users);
-  const mappedLabels = toKeyValueMap(labels);
-  const mappedMilestones = toKeyValueMap(milestones);
 
   const [checkedIssues, checkedIssuesDispatch] = useReducer(checkedIssuesReducer, []);
   const [isQuery, isQueryDispatch] = useReducer(isQueryReducer, window.location.search !== '');
@@ -117,6 +65,17 @@ const IssueList = () => {
     reloadDispatch({ type: 'switch' });
   };
 
+  const toKeyValueMap = (records) => {
+    if (!records) return;
+    const map = {};
+    records.forEach((record) => {
+      map[record.id] = record;
+    });
+    return map;
+  };
+  const mappedUsers = toKeyValueMap(users);
+  const mappedLabels = toKeyValueMap(labels);
+  const mappedMilestones = toKeyValueMap(milestones);
   const getMetaData = (issue) => {
     return {
       issue,
@@ -151,7 +110,6 @@ const IssueList = () => {
           </IsCheckAllContext.Provider>
         </AllCheckedContext.Provider>
       </IsMarkAsContext.Provider>
-      {console.log(checkedIssues)}
     </div>
   );
 };

--- a/Frontend/Views/Components/IssueList/IssueList.js
+++ b/Frontend/Views/Components/IssueList/IssueList.js
@@ -1,12 +1,10 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useReducer, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import IssueListItem from './IssueListItem';
 import TopFilter from './TopFilter';
 import MarkAs from './MarkAs';
 import Alma from './Alma';
-// eslint-disable-next-line import/no-cycle
 import { MilestonesContext, LabelsContext, UsersContext } from '../../App';
-// eslint-disable-next-line import/no-cycle
 import { IssuesContext, ReloadContext } from '../../Pages/IssuesPage';
 
 const toKeyValueMap = (records) => {
@@ -18,6 +16,58 @@ const toKeyValueMap = (records) => {
   return map;
 };
 
+const isQueryReducer = (isQuery, { type, data }) => {
+  switch (type) {
+    case 'switch':
+      return data;
+    default:
+  }
+};
+
+const checkedIssuesReducer = (checkedIssues, { type, data, option }) => {
+  switch (type) {
+    case 'addAll':
+      return data;
+    case 'deleteAll':
+      return [];
+    case 'add':
+      return [...checkedIssues, data];
+    case 'filter':
+      return checkedIssues.filter((elem) => elem !== option);
+    default:
+  }
+};
+
+const isCheckAllReducer = (isCheckAll, { type, data }) => {
+  switch (type) {
+    case 'set':
+      return data;
+    default:
+  }
+};
+
+const allCheckedReducer = (allChecked, { type, data }) => {
+  switch (type) {
+    case 'set':
+      return data;
+    default:
+  }
+};
+
+const isMarkAsReducer = (isMarkAs, { type, data }) => {
+  switch (type) {
+    case 'set':
+      return data;
+    default:
+  }
+};
+
+export const IsQueryContext = React.createContext();
+export const CheckedIssuesContext = React.createContext();
+export const IsCheckAllContext = React.createContext();
+export const AllCheckedContext = React.createContext();
+export const IsMarkAsContext = React.createContext();
+
 const IssueList = () => {
   const { reloadDispatch } = useContext(ReloadContext);
   const { issues } = useContext(IssuesContext);
@@ -28,74 +78,79 @@ const IssueList = () => {
   const mappedLabels = toKeyValueMap(labels);
   const mappedMilestones = toKeyValueMap(milestones);
 
-  const [checkedIssues, setCheckedIssues] = useState([]);
-  const [isCheckAll, setIsCheckAll] = useState(false);
-  const [allChecked, setAllChecked] = useState(false);
-  const [isMarkAs, setIsMarkAs] = useState(false);
-  const [resetQuery, setResetQuery] = useState(window.location.search !== '');
+  const [checkedIssues, checkedIssuesDispatch] = useReducer(checkedIssuesReducer, []);
+  const [isQuery, isQueryDispatch] = useReducer(isQueryReducer, window.location.search !== '');
+  const [isCheckAll, isCheckAllDispatch] = useReducer(isCheckAllReducer, false);
+  const [allChecked, allCheckedDispatch] = useReducer(allCheckedReducer, false);
+  const [isMarkAs, isMarkAsDispatch] = useReducer(isMarkAsReducer, false);
 
   const history = useHistory();
 
   useEffect(() => {
     if (checkedIssues.length === 0) {
-      setAllChecked(false);
-      setIsMarkAs(false);
+      allCheckedDispatch({ type: 'set', data: false });
+      isMarkAsDispatch({ type: 'set', data: false });
     } else if (checkedIssues.length === issues.length) {
-      setAllChecked(true);
-      setIsMarkAs(true);
+      allCheckedDispatch({ type: 'set', data: true });
+      isMarkAsDispatch({ type: 'set', data: true });
     } else if (checkedIssues.length > 0) {
-      setIsMarkAs(true);
+      isMarkAsDispatch({ type: 'set', data: true });
     }
   }, [checkedIssues]);
 
   const onCheckAll = () => {
     if (isCheckAll && !allChecked) {
-      setCheckedIssues(issues.map((issue) => issue.id));
-      setAllChecked(true);
+      checkedIssuesDispatch({ type: 'addAll', data: issues.map((issue) => issue.id) });
+      allCheckedDispatch({ type: 'set', data: true });
     } else if (isCheckAll) {
-      setIsCheckAll(false);
-      setCheckedIssues([]);
+      isCheckAllDispatch({ type: 'set', data: false });
+      checkedIssuesDispatch({ type: 'deleteAll' });
     } else {
-      setIsCheckAll(true);
-      setCheckedIssues(issues.map((issue) => issue.id));
+      isCheckAllDispatch({ type: 'set', data: true });
+      checkedIssuesDispatch({ type: 'addAll', data: issues.map((issue) => issue.id) });
     }
   };
 
   const onClickReset = () => {
-    setResetQuery(false);
+    isQueryDispatch({ type: 'switch', data: false });
     history.push('/issues');
     reloadDispatch({ type: 'switch' });
   };
 
+  const getMetaData = (issue) => {
+    return {
+      issue,
+      author: mappedUsers[issue.userId],
+      labels: issue.labels || issue.labels.map((id) => mappedLabels[id]),
+      assignees: issue.assignees || issue.assignees.map((id) => mappedUsers[id]),
+      milestone: mappedMilestones[issue.milestoneId],
+    };
+  };
+
   return (
     <div>
-      <TopFilter setResetQuery={setResetQuery} />
-      {resetQuery && (
-        <button type="button" onClick={onClickReset}>
-          Clear current search query, filters, and sorts
-        </button>
-      )}
-      <input type="checkbox" onChange={onCheckAll} checked={allChecked} />
-      {isMarkAs && <MarkAs checkedIssues={checkedIssues} setIsMarkAs={setIsMarkAs} setAllChecked={setAllChecked} />}
-      {!isMarkAs && (
-        <Alma users={mappedUsers} labels={mappedLabels} milestones={mappedMilestones} setResetQuery={setResetQuery} />
-      )}
-      {issues.map((issue) => (
-        <IssueListItem
-          key={issue.id}
-          issue={issue}
-          author={mappedUsers[issue.userId]}
-          labels={issue.labels.map((id) => mappedLabels[id])}
-          assignees={issue.assignees.map((id) => mappedUsers[id])}
-          milestone={mappedMilestones[issue.milestoneId]}
-          setCheckedIssues={setCheckedIssues}
-          checkedIssues={checkedIssues}
-          isCheckAll={isCheckAll}
-          setAllChecked={setAllChecked}
-          allChecked={allChecked}
-          isMarkAs={isMarkAs}
-        />
-      ))}
+      <IsMarkAsContext.Provider value={{ isMarkAs, isMarkAsDispatch }}>
+        <AllCheckedContext.Provider value={{ allChecked, allCheckedDispatch }}>
+          <IsCheckAllContext.Provider value={{ isCheckAll }}>
+            <CheckedIssuesContext.Provider value={{ checkedIssues, checkedIssuesDispatch }}>
+              <IsQueryContext.Provider value={{ isQueryDispatch }}>
+                <TopFilter />
+                {isQuery && (
+                  <button type="button" onClick={onClickReset}>
+                    Clear current search query, filters, and sorts
+                  </button>
+                )}
+                <input type="checkbox" onChange={onCheckAll} checked={allChecked} />
+                {isMarkAs && <MarkAs />}
+                {!isMarkAs && <Alma users={mappedUsers} labels={mappedLabels} milestones={mappedMilestones} />}
+                {issues.map((issue) => (
+                  <IssueListItem key={issue.id} issueMetaData={getMetaData(issue)} />
+                ))}
+              </IsQueryContext.Provider>
+            </CheckedIssuesContext.Provider>
+          </IsCheckAllContext.Provider>
+        </AllCheckedContext.Provider>
+      </IsMarkAsContext.Provider>
     </div>
   );
 };

--- a/Frontend/Views/Components/IssueList/IssueListItem.js
+++ b/Frontend/Views/Components/IssueList/IssueListItem.js
@@ -1,20 +1,14 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { useHistory } from 'react-router-dom';
+import { CheckedIssuesContext, IsCheckAllContext, AllCheckedContext, IsMarkAsContext } from './IssueList';
 
-const IssueListItem = ({
-  issue,
-  author,
-  labels,
-  assignees,
-  milestone,
-  setCheckedIssues,
-  checkedIssues,
-  isCheckAll,
-  setAllChecked,
-  allChecked,
-  isMarkAs,
-}) => {
+const IssueListItem = ({ issueMetaData }) => {
   const [isChecked, setIsChecked] = useState(false);
+  const { checkedIssuesDispatch } = useContext(CheckedIssuesContext);
+  const { isCheckAll } = useContext(IsCheckAllContext);
+  const { allChecked, allCheckedDispatch } = useContext(AllCheckedContext);
+  const { isMarkAs } = useContext(IsMarkAsContext);
+  const { issue, author, labels, assignees, milestone } = issueMetaData;
 
   const history = useHistory();
 
@@ -37,11 +31,11 @@ const IssueListItem = ({
   const onCheckIssue = () => {
     if (isChecked === false) {
       setIsChecked(true);
-      setCheckedIssues([...checkedIssues, issue.id]);
+      checkedIssuesDispatch({ type: 'add', data: issue.id });
     } else {
       setIsChecked(false);
-      setCheckedIssues(checkedIssues.filter((elem) => elem !== issue.id));
-      setAllChecked(false);
+      checkedIssuesDispatch({ type: 'filter', option: issue.id });
+      allCheckedDispatch({ type: 'set', data: false });
     }
   };
 

--- a/Frontend/Views/Components/IssueList/IssueListItem.js
+++ b/Frontend/Views/Components/IssueList/IssueListItem.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { useHistory } from 'react-router-dom';
-import { CheckedIssuesContext, IsCheckAllContext, AllCheckedContext, IsMarkAsContext } from './IssueList';
+import { CheckedIssuesContext, IsCheckAllContext, AllCheckedContext, IsMarkAsContext } from '../../store/IssuesListStore';
 
 const IssueListItem = ({ issueMetaData }) => {
   const [isChecked, setIsChecked] = useState(false);

--- a/Frontend/Views/Components/IssueList/IssueListItem.js
+++ b/Frontend/Views/Components/IssueList/IssueListItem.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 
 const IssueListItem = ({

--- a/Frontend/Views/Components/IssueList/MarkAs.js
+++ b/Frontend/Views/Components/IssueList/MarkAs.js
@@ -1,8 +1,8 @@
 import React, { useState, useContext } from 'react';
 import axios from 'axios';
 import useClickOutside from '../Modal';
-import { ReloadContext } from '../../Pages/IssuesPage';
-import { CheckedIssuesContext, AllCheckedContext, IsMarkAsContext } from './IssueList';
+import { ReloadContext } from '../../store/IssuesPageStore';
+import { CheckedIssuesContext, AllCheckedContext, IsMarkAsContext } from '../../store/IssuesListStore';
 
 const MarkAs = () => {
   const { reloadDispatch } = useContext(ReloadContext);

--- a/Frontend/Views/Components/IssueList/MarkAs.js
+++ b/Frontend/Views/Components/IssueList/MarkAs.js
@@ -2,9 +2,14 @@ import React, { useState, useContext } from 'react';
 import axios from 'axios';
 import useClickOutside from '../Modal';
 import { ReloadContext } from '../../Pages/IssuesPage';
+import { CheckedIssuesContext, AllCheckedContext, IsMarkAsContext } from './IssueList';
 
-const MarkAs = ({ checkedIssues, setIsMarkAs, setAllChecked }) => {
+const MarkAs = () => {
   const { reloadDispatch } = useContext(ReloadContext);
+  const { checkedIssues } = useContext(CheckedIssuesContext);
+  const { allCheckedDispatch } = useContext(AllCheckedContext);
+  const { isMarkAsDispatch } = useContext(IsMarkAsContext);
+
   const [isVisible, setIsVisible] = useState(false);
 
   const domNode = useClickOutside(() => {
@@ -17,18 +22,17 @@ const MarkAs = ({ checkedIssues, setIsMarkAs, setAllChecked }) => {
 
   const MarkAsList = () => {
     const onChangeStatus = async (status) => {
+      const URL = `${process.env.API_URL}/${process.env.API_VERSION}/issues/status`;
+      const config = { withCredentials: true };
+      const postData = {
+        issues: checkedIssues,
+        isOpen: status,
+      };
       try {
-        await axios.patch(
-          'http://localhost:3000/api/v1/issues/status',
-          {
-            issues: checkedIssues,
-            isOpen: status,
-          },
-          { withCredentials: true },
-        );
+        await axios.patch(URL, postData, config);
         onToggleDropdown();
-        setIsMarkAs(false);
-        setAllChecked(false);
+        isMarkAsDispatch({ type: 'set', data: false });
+        allCheckedDispatch({ type: 'set', data: false });
         reloadDispatch({ type: 'switch' });
       } catch (err) {
         console.log('error');
@@ -50,7 +54,7 @@ const MarkAs = ({ checkedIssues, setIsMarkAs, setAllChecked }) => {
         <button type="button" onClick={onToggleDropdown}>
           Mark as
         </button>
-        {isVisible && <MarkAsList checkedIssues={checkedIssues} />}
+        {isVisible && <MarkAsList />}
       </div>
     </>
   );

--- a/Frontend/Views/Components/IssueList/MarkAs.js
+++ b/Frontend/Views/Components/IssueList/MarkAs.js
@@ -6,7 +6,7 @@ import { CheckedIssuesContext, AllCheckedContext, IsMarkAsContext } from './Issu
 
 const MarkAs = () => {
   const { reloadDispatch } = useContext(ReloadContext);
-  const { checkedIssues } = useContext(CheckedIssuesContext);
+  const { checkedIssues, checkedIssuesDispatch } = useContext(CheckedIssuesContext);
   const { allCheckedDispatch } = useContext(AllCheckedContext);
   const { isMarkAsDispatch } = useContext(IsMarkAsContext);
 
@@ -33,6 +33,7 @@ const MarkAs = () => {
         onToggleDropdown();
         isMarkAsDispatch({ type: 'set', data: false });
         allCheckedDispatch({ type: 'set', data: false });
+        checkedIssuesDispatch({ type: 'deleteAll' });
         reloadDispatch({ type: 'switch' });
       } catch (err) {
         console.log('error');

--- a/Frontend/Views/Components/IssueList/MarkAs.js
+++ b/Frontend/Views/Components/IssueList/MarkAs.js
@@ -1,8 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import axios from 'axios';
 import useClickOutside from '../Modal';
+import { ReloadContext } from '../../Pages/IssuesPage';
 
-const MarkAs = ({ checkedIssues, reloadIssue, setIsMarkAs, setAllChecked }) => {
+const MarkAs = ({ checkedIssues, setIsMarkAs, setAllChecked }) => {
+  const { reloadDispatch } = useContext(ReloadContext);
   const [isVisible, setIsVisible] = useState(false);
 
   const domNode = useClickOutside(() => {
@@ -27,7 +29,7 @@ const MarkAs = ({ checkedIssues, reloadIssue, setIsMarkAs, setAllChecked }) => {
         onToggleDropdown();
         setIsMarkAs(false);
         setAllChecked(false);
-        reloadIssue();
+        reloadDispatch({ type: 'switch' });
       } catch (err) {
         console.log('error');
       }
@@ -48,7 +50,7 @@ const MarkAs = ({ checkedIssues, reloadIssue, setIsMarkAs, setAllChecked }) => {
         <button type="button" onClick={onToggleDropdown}>
           Mark as
         </button>
-        {isVisible && <MarkAsList checkedIssues={checkedIssues} reloadIssue={reloadIssue} />}
+        {isVisible && <MarkAsList checkedIssues={checkedIssues} />}
       </div>
     </>
   );

--- a/Frontend/Views/Components/IssueList/TopFilter.js
+++ b/Frontend/Views/Components/IssueList/TopFilter.js
@@ -1,9 +1,12 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 import useClickOutside from '../Modal';
 import getUserId from '../../../Sources/user';
+import { ReloadContext } from '../../Pages/IssuesPage';
 
-const TopFilter = ({ reloadIssue, setResetQuery }) => {
+const TopFilter = ({ setResetQuery }) => {
+  const { reloadDispatch } = useContext(ReloadContext);
+
   const [isVisible, setIsVisible] = useState(false);
   const history = useHistory();
   const domNode = useClickOutside(() => {
@@ -18,20 +21,7 @@ const TopFilter = ({ reloadIssue, setResetQuery }) => {
     history.push(`/issues?${queryString}`);
     onToggleDropdown();
     setResetQuery(true);
-    reloadIssue();
-  };
-
-  const TopFilterMenu = () => {
-    return (
-      <>
-        <div>Filter Issues</div>
-        <div onClick={() => onClickFilter('open=1')}>Open Issues</div>
-        <div onClick={() => onClickFilter(`author=${getUserId(document.cookie)}`)}>Your Issues</div>
-        <div onClick={() => onClickFilter(`assignee=${getUserId(document.cookie)}`)}>Everything assigned to you</div>
-        <div onClick={() => onClickFilter(`mentions=${getUserId(document.cookie)}`)}>Everything mentioning you</div>
-        <div onClick={() => onClickFilter('open=0')}>Closed Issues</div>
-      </>
-    );
+    reloadDispatch({ type: 'switch' });
   };
 
   return (
@@ -41,7 +31,18 @@ const TopFilter = ({ reloadIssue, setResetQuery }) => {
           Filters
         </button>
         <input type="text" />
-        {isVisible && <TopFilterMenu />}
+        {isVisible && (
+          <div>
+            <div>Filter Issues</div>
+            <div onClick={() => onClickFilter('open=1')}>Open Issues</div>
+            <div onClick={() => onClickFilter(`author=${getUserId(document.cookie)}`)}>Your Issues</div>
+            <div onClick={() => onClickFilter(`assignee=${getUserId(document.cookie)}`)}>
+              Everything assigned to you
+            </div>
+            <div onClick={() => onClickFilter(`mentions=${getUserId(document.cookie)}`)}>Everything mentioning you</div>
+            <div onClick={() => onClickFilter('open=0')}>Closed Issues</div>
+          </div>
+        )}
       </div>
     </>
   );

--- a/Frontend/Views/Components/IssueList/TopFilter.js
+++ b/Frontend/Views/Components/IssueList/TopFilter.js
@@ -2,8 +2,8 @@ import React, { useState, useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 import useClickOutside from '../Modal';
 import getUserId from '../../../Sources/user';
-import { ReloadContext } from '../../Pages/IssuesPage';
-import { IsQueryContext } from './IssueList';
+import { ReloadContext } from '../../store/IssuesPageStore';
+import { IsQueryContext } from '../../store/IssuesListStore';
 
 const TopFilter = () => {
   const { reloadDispatch } = useContext(ReloadContext);
@@ -38,9 +38,7 @@ const TopFilter = () => {
             <div>Filter Issues</div>
             <div onClick={() => onClickFilter('open=1')}>Open Issues</div>
             <div onClick={() => onClickFilter(`author=${getUserId(document.cookie)}`)}>Your Issues</div>
-            <div onClick={() => onClickFilter(`assignee=${getUserId(document.cookie)}`)}>
-              Everything assigned to you
-            </div>
+            <div onClick={() => onClickFilter(`assignee=${getUserId(document.cookie)}`)}>Everything assigned to you</div>
             <div onClick={() => onClickFilter(`mentions=${getUserId(document.cookie)}`)}>Everything mentioning you</div>
             <div onClick={() => onClickFilter('open=0')}>Closed Issues</div>
           </div>

--- a/Frontend/Views/Components/IssueList/TopFilter.js
+++ b/Frontend/Views/Components/IssueList/TopFilter.js
@@ -3,9 +3,11 @@ import { useHistory } from 'react-router-dom';
 import useClickOutside from '../Modal';
 import getUserId from '../../../Sources/user';
 import { ReloadContext } from '../../Pages/IssuesPage';
+import { IsQueryContext } from './IssueList';
 
-const TopFilter = ({ setResetQuery }) => {
+const TopFilter = () => {
   const { reloadDispatch } = useContext(ReloadContext);
+  const { isQueryDispatch } = useContext(IsQueryContext);
 
   const [isVisible, setIsVisible] = useState(false);
   const history = useHistory();
@@ -20,7 +22,7 @@ const TopFilter = ({ setResetQuery }) => {
   const onClickFilter = (queryString) => {
     history.push(`/issues?${queryString}`);
     onToggleDropdown();
-    setResetQuery(true);
+    isQueryDispatch({ type: 'switch', data: true });
     reloadDispatch({ type: 'switch' });
   };
 

--- a/Frontend/Views/Components/IssueList/TopFilter.js
+++ b/Frontend/Views/Components/IssueList/TopFilter.js
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 import useClickOutside from '../Modal';
-import getUserId from '../../../Sources/user';
+import { getUserId } from '../../../Sources/user';
 import { ReloadContext } from '../../store/IssuesPageStore';
 import { IsQueryContext } from '../../store/IssuesListStore';
 

--- a/Frontend/Views/Components/Label/LabelForm.js
+++ b/Frontend/Views/Components/Label/LabelForm.js
@@ -1,8 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import axios from 'axios';
 import getRandomColor from '../../../Sources/color';
+import { LabelsContext } from '../../store/AppStore';
 
-const LabelForm = ({ setIsFormVisible, labels, setLabels, isEdit, labelToEdit }) => {
+const LabelForm = ({ setIsFormVisible, isEdit, labelToEdit }) => {
+  const { labelsDispatch } = useContext(LabelsContext);
   const [name, setName] = useState('');
   const [color, setColor] = useState(getRandomColor());
   const [description, setDescription] = useState('');
@@ -57,7 +59,7 @@ const LabelForm = ({ setIsFormVisible, labels, setLabels, isEdit, labelToEdit })
     try {
       // TODO: 넣은 행에 대한 InsertId 받아오기
       const { data } = await axios.post(LABEL_URL, postData, { withCredentials: true });
-      setLabels([...labels, { ...postData, id: data.insertId }]);
+      labelsDispatch({ type: 'add', data: { ...postData, id: data.insertId } });
     } catch (err) {
       console.log(err.message);
     }
@@ -65,21 +67,11 @@ const LabelForm = ({ setIsFormVisible, labels, setLabels, isEdit, labelToEdit })
 
   const onClickEdit = async () => {
     const LABEL_URL = `${process.env.API_URL}/${process.env.API_VERSION}/labels`;
-    const postData = {
-      name,
-      description,
-      color,
-    };
+    const postData = { name, description, color };
+
     try {
       await axios.patch(`${LABEL_URL}/${labelToEdit.id}`, postData, { withCredentials: true });
-      setLabels(
-        labels.map((label) => {
-          if (label.id === labelToEdit.id) {
-            return Object.assign(label, postData);
-          }
-          return label;
-        }),
-      );
+      labelsDispatch({ type: 'targetUpdate', data: postData, target: labelToEdit.id });
     } catch (err) {
       console.log(err.message);
     }

--- a/Frontend/Views/Components/Label/LabelList.js
+++ b/Frontend/Views/Components/Label/LabelList.js
@@ -9,7 +9,6 @@ const LabelList = ({ setIsFormVisible }) => {
     const LABEL_URL = `${process.env.API_URL}/${process.env.API_VERSION}/labels`;
     try {
       await axios.delete(`${LABEL_URL}/${id}`, { withCredentials: true });
-      // setLabels(labels.filter((label) => label.id !== id));
       labelsDispatch({ type: 'delete', target: id });
     } catch (err) {
       console.log('error');
@@ -37,12 +36,8 @@ const LabelList = ({ setIsFormVisible }) => {
 
   return (
     <>
-      <div>{`${labels.length} labels`}</div>
-      {labels.map((label) => (
-        <>
-          <LabelItem key={label.id} label={label} />
-        </>
-      ))}
+      <div>{`${labels?.length} labels`}</div>
+      {labels && labels.map((label) => <LabelItem key={label.id} label={label} />)}
     </>
   );
 };

--- a/Frontend/Views/Components/Label/LabelList.js
+++ b/Frontend/Views/Components/Label/LabelList.js
@@ -1,13 +1,16 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import axios from 'axios';
 import LabelForm from './LabelForm';
+import { LabelsContext } from '../../store/AppStore';
 
-const LabelList = ({ labels, setLabels, setIsFormVisible }) => {
+const LabelList = ({ setIsFormVisible }) => {
+  const { labels, labelsDispatch } = useContext(LabelsContext);
   const onClickDelete = async (id) => {
     const LABEL_URL = `${process.env.API_URL}/${process.env.API_VERSION}/labels`;
     try {
       await axios.delete(`${LABEL_URL}/${id}`, { withCredentials: true });
-      setLabels(labels.filter((label) => label.id !== id));
+      // setLabels(labels.filter((label) => label.id !== id));
+      labelsDispatch({ type: 'delete', target: id });
     } catch (err) {
       console.log('error');
     }
@@ -26,15 +29,7 @@ const LabelList = ({ labels, setLabels, setIsFormVisible }) => {
           <button type="button" onClick={() => onClickDelete(label.id)}>
             Delete
           </button>
-          {isEdit && (
-            <LabelForm
-              isEdit
-              labels={labels}
-              labelToEdit={label}
-              setLabels={setLabels}
-              setIsFormVisible={setIsFormVisible}
-            />
-          )}
+          {isEdit && <LabelForm isEdit labelToEdit={label} setIsFormVisible={setIsFormVisible} />}
         </div>
       </>
     );

--- a/Frontend/Views/Components/NewIssue/NewIssueDropdown.js
+++ b/Frontend/Views/Components/NewIssue/NewIssueDropdown.js
@@ -16,7 +16,7 @@ const NewIssueDropdown = ({ dropdownTitle, selected, setSelected, children }) =>
       {isOpen && <NewIssueList setSelected={setSelected} selected={selected} data={[...children]} />}
 
       <div id={`${dropdownTitle} selected`}>
-        {selected.map((elem) => (
+        {selected?.map((elem) => (
           <span key={elem.id}>{elem.username || elem.name || elem.title}</span>
         ))}
       </div>

--- a/Frontend/Views/Components/NewIssue/NewIssueForm.js
+++ b/Frontend/Views/Components/NewIssue/NewIssueForm.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import axios from 'axios';
 import MarkdownRender from '../MarkdownRender';
@@ -6,7 +6,7 @@ import ErrorMessage from '../ErrorMessage';
 import { getUserId, getUserImageLink } from '../../../Sources/user';
 import UserPhotoBlock from '../UserPhotoBlock';
 
-const NewIssueForm = ({ userSelectedData, labelSelectedData, mileSelectedData }) => {
+const NewIssueForm = ({ selectedUsers, selecetdLabels, selectedMiles }) => {
   const history = useHistory();
 
   const [title, setTitle] = useState('');
@@ -25,12 +25,13 @@ const NewIssueForm = ({ userSelectedData, labelSelectedData, mileSelectedData })
     const postData = {
       title,
       comment,
-      milestoneId: mileSelectedData.map((elem) => elem.id)[0],
-      labels: labelSelectedData.map((elem) => elem.id),
-      assignees: userSelectedData.map((elem) => elem.id),
+      milestoneId: selectedMiles?.map((elem) => elem.id)[0],
+      labels: selecetdLabels?.map((elem) => elem.id),
+      assignees: selectedUsers?.map((elem) => elem.id),
     };
     try {
       await axios.post(ISSUE_URL, postData, { withCredentials: true });
+      // issuesDispatch({type:'add',data:postData})
       window.location.href = `${process.env.WEB_URL}/issues`;
     } catch (err) {
       window.location.href = process.env.WEB_URL;
@@ -93,12 +94,7 @@ const NewIssueForm = ({ userSelectedData, labelSelectedData, mileSelectedData })
       <input type="text" placeholder="Title" onChange={onChangeTitle} />
       {titleError && <ErrorMessage message="제목을 입력해주세요." />}
       <textarea type="text" placeholder="Leave a comment" onChange={onChangeComment} value={comment} />
-      <input
-        placeholder="Attach files by selecting here"
-        type="file"
-        accept="image/png, image/jpeg, image/jpg"
-        onChange={onUploadImage}
-      />
+      <input placeholder="Attach files by selecting here" type="file" accept="image/png, image/jpeg, image/jpg" onChange={onUploadImage} />
       {commentError && <ErrorMessage message="본문을 입력해주세요." />}
       {imageError && <ErrorMessage message="이미지 업로드에 실패했습니다." />}
       <button type="button" onClick={onClickCancel}>

--- a/Frontend/Views/Components/NewIssue/NewIssueWrapper.js
+++ b/Frontend/Views/Components/NewIssue/NewIssueWrapper.js
@@ -3,24 +3,20 @@ import NewIssueForm from './NewIssueForm';
 import NewIssueOption from '../NewIssueOption';
 
 const NewIssueWrapper = () => {
-  const [userSelectedData, setUserSelectedData] = useState([]);
-  const [labelSelectedData, setLabelSelectedData] = useState([]);
-  const [mileSelectedData, setMileSelectedData] = useState([]);
+  const [selectedUsers, setSelectedUsers] = useState([]);
+  const [selectedLabels, setSelectedLabels] = useState([]);
+  const [selecetedMiles, setSelecetedMiles] = useState([]);
 
   return (
     <>
-      <NewIssueForm
-        userSelectedData={userSelectedData}
-        labelSelectedData={labelSelectedData}
-        mileSelectedData={mileSelectedData}
-      />
+      <NewIssueForm selectedUsers={selectedUsers} selectedLabels={selectedLabels} selecetedMiles={selecetedMiles} />
       <NewIssueOption
-        userSelectedData={userSelectedData}
-        labelSelectedData={labelSelectedData}
-        mileSelectedData={mileSelectedData}
-        setUserSelectedData={setUserSelectedData}
-        setLabelSelectedData={setLabelSelectedData}
-        setMileSelectedData={setMileSelectedData}
+        selectedUsers={selectedUsers}
+        selectedLabels={selectedLabels}
+        selecetedMiles={selecetedMiles}
+        setSelectedUsers={setSelectedUsers}
+        setSelectedLabels={setSelectedLabels}
+        setSelecetedMiles={setSelecetedMiles}
       />
     </>
   );

--- a/Frontend/Views/Components/NewIssueOption.js
+++ b/Frontend/Views/Components/NewIssueOption.js
@@ -1,48 +1,22 @@
-import React, { useEffect, useState } from 'react';
-import axios from 'axios';
+import React, { useContext } from 'react';
 import NewIssueDropdown from './NewIssue/NewIssueDropdown';
+import { UsersContext, LabelsContext, MilestonesContext } from '../store/AppStore';
 
-const NewIssueOption = ({
-  userSelectedData,
-  labelSelectedData,
-  mileSelectedData,
-  setUserSelectedData,
-  setLabelSelectedData,
-  setMileSelectedData,
-}) => {
-  const [userData, setUser] = useState('');
-  const [labelData, setLabel] = useState('');
-  const [mileData, setMile] = useState('');
-
-  useEffect(async () => {
-    const USER_URL = `${process.env.API_URL}/${process.env.API_VERSION}/users`;
-    const LABEL_URL = `${process.env.API_URL}/${process.env.API_VERSION}/labels`;
-    const MILE_URL = `${process.env.API_URL}/${process.env.API_VERSION}/milestones`;
-
-    const userProm = axios.get(USER_URL, { withCredentials: true });
-    const labelProm = axios.get(LABEL_URL, { withCredentials: true });
-    const mileProm = axios.get(MILE_URL, { withCredentials: true });
-
-    try {
-      const [userResolve, labelResolve, mileResolve] = await Promise.all([userProm, labelProm, mileProm]);
-      setUser(userResolve.data);
-      setLabel(labelResolve.data);
-      setMile(mileResolve.data);
-    } catch (err) {
-      window.location.href = process.env.WEB_URL;
-    }
-  }, []);
+const NewIssueOption = ({ selectedUsers, selecetdLabels, selectedMiles, setSelectedUsers, setSelectedLabels, setSelectedMiles }) => {
+  const { users } = useContext(UsersContext);
+  const { labels } = useContext(LabelsContext);
+  const { milestones } = useContext(MilestonesContext);
 
   return (
     <div>
-      <NewIssueDropdown dropdownTitle="Assignees" selected={userSelectedData} setSelected={setUserSelectedData}>
-        {userData}
+      <NewIssueDropdown dropdownTitle="Assignees" selected={selectedUsers} setSelected={setSelectedUsers}>
+        {users}
       </NewIssueDropdown>
-      <NewIssueDropdown dropdownTitle="Labels" selected={labelSelectedData} setSelected={setLabelSelectedData}>
-        {labelData}
+      <NewIssueDropdown dropdownTitle="Labels" selected={selecetdLabels} setSelected={setSelectedLabels}>
+        {labels}
       </NewIssueDropdown>
-      <NewIssueDropdown dropdownTitle="Milestones" selected={mileSelectedData} setSelected={setMileSelectedData}>
-        {mileData}
+      <NewIssueDropdown dropdownTitle="Milestones" selected={selectedMiles} setSelected={setSelectedMiles}>
+        {milestones}
       </NewIssueDropdown>
     </div>
   );

--- a/Frontend/Views/Pages/IssuesPage.js
+++ b/Frontend/Views/Pages/IssuesPage.js
@@ -1,27 +1,7 @@
 import React, { useEffect, useReducer, useContext } from 'react';
 import axios from 'axios';
 import IssueList from '../Components/IssueList/IssueList';
-
-const issuesReducer = (issues, { type, data }) => {
-  switch (type) {
-    case 'setInitial':
-      return data;
-    default:
-  }
-};
-
-const reloadReducer = (reload, { type }) => {
-  switch (type) {
-    case 'setInitial':
-      return true;
-    case 'switch':
-      return !reload;
-    default:
-  }
-};
-
-export const IssuesContext = React.createContext();
-export const ReloadContext = React.createContext();
+import { issuesReducer, reloadReducer, IssuesContext, ReloadContext } from '../store/IssuesPageStore';
 
 const IssuesPage = () => {
   const [issues, issuesDispatch] = useReducer(issuesReducer, []);

--- a/Frontend/Views/Pages/IssuesPage.js
+++ b/Frontend/Views/Pages/IssuesPage.js
@@ -1,69 +1,59 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useReducer, useContext } from 'react';
 import axios from 'axios';
+// eslint-disable-next-line import/no-cycle
 import IssueList from '../Components/IssueList/IssueList';
 
-const toKeyValueMap = (records) => {
-  const map = {};
-  records.forEach((record) => {
-    map[record.id] = record;
-  });
-  return map;
+const issuesReducer = (issues, { type, data }) => {
+  // eslint-disable-next-line default-case
+  switch (type) {
+    case 'setInitial':
+      return data;
+  }
 };
 
-const IssuesPage = () => {
-  const [data, setData] = useState({ issueData: [], userData: [], labelData: [], mileData: [] });
-  const [issueReload, setIssueReload] = useState(true);
+const reloadReducer = (reload, { type }) => {
+  // eslint-disable-next-line default-case
+  switch (type) {
+    case 'setInitial':
+      return true;
+    case 'switch':
+      return !reload;
+  }
+};
 
-  const reloadIssue = () => {
-    setIssueReload((prevIssueReload) => !prevIssueReload);
-  };
+export const IssuesContext = React.createContext();
+export const ReloadContext = React.createContext();
+
+const IssuesPage = () => {
+  const [issues, issuesDispatch] = useReducer(issuesReducer, []);
+  const [reload, reloadDispatch] = useReducer(reloadReducer, []);
 
   useEffect(async () => {
     const ISSUE_URL = `${process.env.API_URL}/${process.env.API_VERSION}/issues`;
-    const USER_URL = `${process.env.API_URL}/${process.env.API_VERSION}/users`;
-    const LABEL_URL = `${process.env.API_URL}/${process.env.API_VERSION}/labels`;
-    const MILE_URL = `${process.env.API_URL}/${process.env.API_VERSION}/milestones`;
-
     const queryString = window.location.search;
-    const issueProm = axios.get(`${ISSUE_URL}${queryString}`, { withCredentials: true });
-    const userProm = axios.get(USER_URL, { withCredentials: true });
-    const labelProm = axios.get(LABEL_URL, { withCredentials: true });
-    const mileProm = axios.get(MILE_URL, { withCredentials: true });
 
     try {
-      const [issueResolve, userResolve, labelResolve, milesResolve] = await Promise.all([
-        issueProm,
-        userProm,
-        labelProm,
-        mileProm,
-      ]);
-
-      setData({
-        issueData: issueResolve.data,
-        userData: toKeyValueMap(userResolve.data),
-        labelData: toKeyValueMap(labelResolve.data),
-        mileData: toKeyValueMap(milesResolve.data),
-      });
+      const issueResolve = await axios.get(`${ISSUE_URL}${queryString}`, { withCredentials: true });
+      issuesDispatch({ type: 'setInitial', data: issueResolve.data });
+      reloadDispatch({ type: 'setInitial' });
     } catch (err) {
       window.location.href = process.env.WEB_URL;
     }
-  }, [issueReload]);
+  }, [reload]);
 
   useEffect(() => {
-    const reloadWhenPopstate = () => reloadIssue();
+    const reloadWhenPopstate = () => reloadDispatch({ type: 'switch' });
     window.addEventListener('popstate', reloadWhenPopstate);
     return () => window.removeEventListener('popstate', reloadWhenPopstate);
   }, []);
 
   return (
     <div>
-      <IssueList
-        issues={data.issueData}
-        users={data.userData}
-        labels={data.labelData}
-        milestones={data.mileData}
-        reloadIssue={reloadIssue}
-      />
+      <ReloadContext.Provider value={{ reloadDispatch }}>
+        <IssuesContext.Provider value={{ issues, issuesDispatch }}>
+          <IssueList />
+        </IssuesContext.Provider>
+      </ReloadContext.Provider>
     </div>
   );
 };

--- a/Frontend/Views/Pages/IssuesPage.js
+++ b/Frontend/Views/Pages/IssuesPage.js
@@ -1,23 +1,22 @@
 import React, { useEffect, useReducer, useContext } from 'react';
 import axios from 'axios';
-// eslint-disable-next-line import/no-cycle
 import IssueList from '../Components/IssueList/IssueList';
 
 const issuesReducer = (issues, { type, data }) => {
-  // eslint-disable-next-line default-case
   switch (type) {
     case 'setInitial':
       return data;
+    default:
   }
 };
 
 const reloadReducer = (reload, { type }) => {
-  // eslint-disable-next-line default-case
   switch (type) {
     case 'setInitial':
       return true;
     case 'switch':
       return !reload;
+    default:
   }
 };
 

--- a/Frontend/Views/Pages/LabelPage.js
+++ b/Frontend/Views/Pages/LabelPage.js
@@ -7,15 +7,7 @@ import { LabelsContext } from '../store/AppStore';
 
 const LabelPage = () => {
   const { labels } = useContext(LabelsContext);
-  // const [labels, setLabels] = useState([]);
   const [isFormVisible, setIsFormVisible] = useState(false);
-
-  // useEffect(async () => {
-  //   const { data } = await axios.get(`${process.env.API_URL}/${process.env.API_VERSION}/labels`, {
-  //     withCredentials: true,
-  //   });
-  //   setLabels(data);
-  // }, []);
 
   const onToggleForm = () => {
     setIsFormVisible(!isFormVisible);

--- a/Frontend/Views/Pages/LabelPage.js
+++ b/Frontend/Views/Pages/LabelPage.js
@@ -1,19 +1,21 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
 import LabelList from '../Components/Label/LabelList';
 import LabelForm from '../Components/Label/LabelForm';
+import { LabelsContext } from '../store/AppStore';
 
 const LabelPage = () => {
-  const [labels, setLabels] = useState([]);
+  const { labels } = useContext(LabelsContext);
+  // const [labels, setLabels] = useState([]);
   const [isFormVisible, setIsFormVisible] = useState(false);
 
-  useEffect(async () => {
-    const { data } = await axios.get(`${process.env.API_URL}/${process.env.API_VERSION}/labels`, {
-      withCredentials: true,
-    });
-    setLabels(data);
-  }, []);
+  // useEffect(async () => {
+  //   const { data } = await axios.get(`${process.env.API_URL}/${process.env.API_VERSION}/labels`, {
+  //     withCredentials: true,
+  //   });
+  //   setLabels(data);
+  // }, []);
 
   const onToggleForm = () => {
     setIsFormVisible(!isFormVisible);
@@ -32,8 +34,8 @@ const LabelPage = () => {
           New Label
         </button>
       </div>
-      {isFormVisible && <LabelForm setIsFormVisible={setIsFormVisible} labels={labels} setLabels={setLabels} />}
-      <LabelList labels={labels} setLabels={setLabels} setIsFormVisible={setIsFormVisible} />
+      {isFormVisible && <LabelForm setIsFormVisible={setIsFormVisible} />}
+      <LabelList labels={labels} setIsFormVisible={setIsFormVisible} />
     </>
   );
 };

--- a/Frontend/Views/store/AppStore.js
+++ b/Frontend/Views/store/AppStore.js
@@ -17,7 +17,7 @@ const labelsReducer = (labels, { type, data, target }) => {
       return [...labels, data];
 
     case 'targetUpdate':
-      return labels.map((label) => {
+      return labels?.map((label) => {
         if (label.id === target) {
           return Object.assign(label, data);
         }

--- a/Frontend/Views/store/AppStore.js
+++ b/Frontend/Views/store/AppStore.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+const milestonesReducer = (milestones, { type, data }) => {
+  switch (type) {
+    case 'setInitial':
+      return data;
+    default:
+  }
+};
+
+const labelsReducer = (labels, { type, data }) => {
+  switch (type) {
+    case 'setInitial':
+      return data;
+    default:
+  }
+};
+
+const usersReducer = (users, { type, data }) => {
+  switch (type) {
+    case 'setInitial':
+      return data;
+    default:
+  }
+};
+
+const MilestonesContext = React.createContext();
+const LabelsContext = React.createContext();
+const UsersContext = React.createContext();
+export { milestonesReducer, labelsReducer, usersReducer, MilestonesContext, LabelsContext, UsersContext };

--- a/Frontend/Views/store/AppStore.js
+++ b/Frontend/Views/store/AppStore.js
@@ -8,10 +8,25 @@ const milestonesReducer = (milestones, { type, data }) => {
   }
 };
 
-const labelsReducer = (labels, { type, data }) => {
+const labelsReducer = (labels, { type, data, target }) => {
   switch (type) {
     case 'setInitial':
       return data;
+
+    case 'add':
+      return [...labels, data];
+
+    case 'targetUpdate':
+      return labels.map((label) => {
+        if (label.id === target) {
+          return Object.assign(label, data);
+        }
+        return label;
+      });
+
+    case 'delete':
+      return labels.filter((label) => label.id !== target);
+
     default:
   }
 };

--- a/Frontend/Views/store/IssuesListStore.js
+++ b/Frontend/Views/store/IssuesListStore.js
@@ -1,0 +1,66 @@
+import React from 'react';
+
+const isQueryReducer = (isQuery, { type, data }) => {
+  switch (type) {
+    case 'switch':
+      return data;
+    default:
+  }
+};
+
+const checkedIssuesReducer = (checkedIssues, { type, data, option }) => {
+  switch (type) {
+    case 'addAll':
+      return data;
+    case 'deleteAll':
+      return [];
+    case 'add':
+      return [...checkedIssues, data];
+    case 'filter':
+      return checkedIssues.filter((elem) => elem !== option);
+    default:
+  }
+};
+
+const isCheckAllReducer = (isCheckAll, { type, data }) => {
+  switch (type) {
+    case 'set':
+      return data;
+    default:
+  }
+};
+
+const allCheckedReducer = (allChecked, { type, data }) => {
+  switch (type) {
+    case 'set':
+      return data;
+    default:
+  }
+};
+
+const isMarkAsReducer = (isMarkAs, { type, data }) => {
+  switch (type) {
+    case 'set':
+      return data;
+    default:
+  }
+};
+
+const IsQueryContext = React.createContext();
+const CheckedIssuesContext = React.createContext();
+const IsCheckAllContext = React.createContext();
+const AllCheckedContext = React.createContext();
+const IsMarkAsContext = React.createContext();
+
+export {
+  isQueryReducer,
+  checkedIssuesReducer,
+  isCheckAllReducer,
+  allCheckedReducer,
+  isMarkAsReducer,
+  IsQueryContext,
+  CheckedIssuesContext,
+  IsCheckAllContext,
+  AllCheckedContext,
+  IsMarkAsContext,
+};

--- a/Frontend/Views/store/IssuesPageStore.js
+++ b/Frontend/Views/store/IssuesPageStore.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const issuesReducer = (issues, { type, data }) => {
+  switch (type) {
+    case 'setInitial':
+      return data;
+    default:
+  }
+};
+
+const reloadReducer = (reload, { type }) => {
+  switch (type) {
+    case 'setInitial':
+      return true;
+    case 'switch':
+      return !reload;
+    default:
+  }
+};
+
+const IssuesContext = React.createContext();
+const ReloadContext = React.createContext();
+
+export { issuesReducer, reloadReducer, IssuesContext, ReloadContext };

--- a/Frontend/webpack.config.js
+++ b/Frontend/webpack.config.js
@@ -24,6 +24,7 @@ module.exports = (env, options) => {
       filename: 'main.js',
       path: path.join(__dirname, 'dist'),
     },
+    devtool: 'eval',
     devServer: {
       port: 8000,
       contentBase: path.join(__dirname, 'dist'),


### PR DESCRIPTION
[comment]: <> (PR 태그를 명시해주세요. [ADD] / [UPDATE] / [BUG])

### 요약
db에 저장되어 있는 데이터를, 한번만 가져오고 난 후 전역으로 관리하기 위해 context-reducer 적용

### 핵심 로직 및 내용
app.js에서 label,milestone,user를 가져와서 context로 사용한다. 
issuePage에서 issue를 가져와서 전역으로 사용한다. 
issueList와 issuePage의 자식 컴포넌트들이 공유하며 사용할 플래그들을 context로 등록하여 사용 

label 페이지는 app.js에서 context로 등록한 label을 가져와서 사용한다.
 
reducer 파일을 분리하여, cycle reference를 최소화 한다. 
전역 context를 사용하는 기능이 추가될 때마다, reducer의 switch문을 업데이트 했음

### 기타 참고 사항
