### PR TITLE
[ADD] 마일스톤, 라벨 이동 버튼 컴포넌트 추가

### DIFF
--- a/Frontend/Views/Components/LabelMilestoneTabs.js
+++ b/Frontend/Views/Components/LabelMilestoneTabs.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import LocalOfferOutlinedIcon from '@material-ui/icons/LocalOfferOutlined';
+import AssistantPhotoOutlinedIcon from '@material-ui/icons/AssistantPhotoOutlined';
+
+const Wrapper = styled.div`
+  width: 250px;
+  border: 1px solid var(--border-gray);
+  border-radius: 5px;
+  background-color: white;
+  overflow: hidden;
+  margin-top: 20px;
+  margin-bottom: 30px;
+  button {
+    border-right: 1px solid var(--border-gray);
+  }
+  &:last-child {
+    border-right: none;
+  }
+`;
+
+const Button = styled.button`
+  width: ${(props) => props.width || '50%'};
+  height: 32px;
+  border-left: none;
+  border-top: none;
+  border-bottom: none;
+  background-color: white;
+  div {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    font-size: 14px;
+  }
+`;
+
+const LabelMilestoneTabs = () => {
+  return (
+    <>
+      <Wrapper>
+        <Link to="/labels">
+          <Button type="button" width="45%">
+            <div>
+              <LocalOfferOutlinedIcon style={{ fontSize: 20 }} />
+              <span>Labels</span>
+            </div>
+          </Button>
+        </Link>
+        <Link to="/milestones">
+          <Button type="button" width="55%">
+            <div>
+              <AssistantPhotoOutlinedIcon style={{ fontSize: 20 }} />
+              <span>Milestones</span>
+            </div>
+          </Button>
+        </Link>
+      </Wrapper>
+    </>
+  );
+};
+
+export default LabelMilestoneTabs;

--- a/Frontend/Views/Pages/LabelPage.js
+++ b/Frontend/Views/Pages/LabelPage.js
@@ -1,9 +1,9 @@
 import React, { useState, useContext } from 'react';
-import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import LabelList from '../Components/Label/LabelList';
 import LabelForm from '../Components/Label/LabelForm';
 import { LabelsContext } from '../store/AppStore';
+import LabelMilestoneTabs from '../Components/LabelMilestoneTabs';
 
 const LabelPageWrapper = styled.div`
   width: 100%;
@@ -22,12 +22,7 @@ const LabelPage = () => {
     <>
       <LabelPageWrapper>
         <div>
-          <Link to="/labels">
-            <button type="button">Lables</button>
-          </Link>
-          <Link to="/milestones">
-            <button type="button">Milestones</button>
-          </Link>
+          <LabelMilestoneTabs />
           <button type="button" onClick={onToggleForm}>
             New Label
           </button>

--- a/Frontend/Views/Pages/MilestonePage.js
+++ b/Frontend/Views/Pages/MilestonePage.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
 import Milestone from '../Components/Milestone/Milestone';
+import LabelMilestoneTabs from '../Components/LabelMilestoneTabs';
 
 const MilestonePage = () => {
   const [milestoneList, setMilestoneList] = useState([]);
@@ -26,8 +27,7 @@ const MilestonePage = () => {
 
   return (
     <div>
-      <Link to="/labels">labels</Link>
-      <Link to="/milestones">milestones</Link>
+      <LabelMilestoneTabs />
       <Link to="/milestones/new">new Milestone</Link>
 
       <button type="button" onClick={onOpenBtnClick}>


### PR DESCRIPTION
[comment]: <> (PR 태그를 명시해주세요. [ADD] / [UPDATE] / [BUG])

### 요약

마일스톤, 라벨 이동 버튼 컴포넌트 추가했습니다. 

### 핵심 로직 및 내용

Labels, Milestones 페이지 두 군데에 컴포넌트로 교체되었습니다. 

### 기타 참고 사항
